### PR TITLE
ci: Update release workflow to version 4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Release Please
-        uses: google-github-actions/release-please-action@v3
+        uses: release-please-oss/release-please-action@v4
         with:
           # "rust" means it knows how to handle Cargo.toml
           release-type: rust


### PR DESCRIPTION
- Upgrade `release-please` action in GitHub workflow to improve
  automation reliability and compatibility with newer dependencies.
- Adjust CI configuration to align with updated release management
  practices.
