### PR TITLE
feat(template-source): pull CV template from a local dir or GitHub repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,1 @@
-/nix/store/65x3bl353nzq6639aqlj6plzxqdfy6ml-pre-commit-config.json
+/nix/store/8a502q095nj0hzk05b132nwqm3jdkjdb-pre-commit-config.json

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@
 
 *✨ The blazingly fast, memory-safe CV generator that turns your LaTeX dreams into reality ✨*
 
-[Features](#-features) • [Installation](#-installation) • [Quick Start](#-quick-start) • [Configuration](#-configuration) • [Usage](#-usage) • [Contributing](#-contributing)
+[Features](#-features) •
+[Installation](#-installation) •
+[Quick Start](#-quick-start) •
+[Configuration](#-configuration) •
+[Usage](#-usage) •
+[Contributing](#-contributing)
 
 </div>
 
@@ -17,9 +22,12 @@
 
 ## 📖 Overview
 
-**Rusty CV Creator** is a powerful command-line tool written in Rust that automates the process of generating personalized CVs for job applications. Say goodbye to manually editing LaTeX templates for every application! 🎯
+**Rusty CV Creator** is a powerful command-line tool written in Rust that
+automates the process of generating personalized CVs for job applications.
+Say goodbye to manually editing LaTeX templates for every application! 🎯
 
 Instead of spending hours tweaking your CV for each position, Rusty CV Creator:
+
 - 📋 **Templates** your CV with placeholders
 - 🔄 **Replaces** job-specific information automatically
 - 🎨 **Compiles** LaTeX to beautiful PDFs
@@ -31,13 +39,15 @@ Perfect for job seekers who want to maintain consistency while customizing their
 ## ✨ Features
 
 ### 🚀 Core Functionality
+
 - **🎯 Smart CV Generation**: Automatically customize CVs for specific companies and positions
-- **📝 LaTeX Integration**: Full LaTeX/XeLaTeX compilation support for professional-quality output  
+- **📝 LaTeX Integration**: Full LaTeX/XeLaTeX compilation support for professional-quality output
 - **🗄️ Database Management**: Track all your applications with SQLite/PostgreSQL support
 - **📂 Intelligent Organization**: Automatic directory structure and file naming
 - **🔍 Application Search**: Filter and find previous applications with advanced queries
 
-### 🛠️ Technical Excellence  
+### 🛠️ Technical Excellence
+
 - **⚡ Blazingly Fast**: Written in Rust for maximum performance
 - **🛡️ Memory Safe**: Zero-cost abstractions with compile-time guarantees
 - **🔧 Configurable**: INI-based configuration system
@@ -45,6 +55,7 @@ Perfect for job seekers who want to maintain consistency while customizing their
 - **🎨 Template-driven**: Flexible placeholder-based template system
 
 ### 🎛️ Command-Line Interface
+
 - **🔧 CRUD Operations**: Create, read, update, and delete CV records
 - **📋 Interactive Selection**: Fuzzy-finding with skim integration
 - **👁️ Preview Support**: Optional PDF viewer integration
@@ -88,7 +99,7 @@ Create your configuration file at `~/.config/rusty-cv-creator/rusty-cv-config.in
 [destination]
 cv_path = "~/Documents/CVs"
 
-[cv]  
+[cv]
 cv_template_path = "~/Documents/cv-template"
 cv_template_file = "cv.tex"
 
@@ -130,11 +141,11 @@ rusty_cv_creator insert "ACME Corporation" "Senior Rust Developer" "Passionate a
 # View the generated CV
 rusty_cv_creator insert "TechCorp" "Software Engineer" "Love building reliable software" --view-generated-cv
 
-# Dry run (test without creating files)  
+# Dry run (test without creating files)
 rusty_cv_creator insert "StartupCo" "Backend Engineer" "Excited about scaling challenges" --dry-run
 ```
 
-## 🛠️ Configuration
+## 🔧 Configuration
 
 ### Database Setup
 
@@ -144,11 +155,12 @@ Set your database URL in your environment or `.env` file:
 # SQLite (recommended for single user)
 echo "DATABASE_URL=sqlite://$HOME/.config/rusty-cv-creator/applications.db" > .env
 
-# PostgreSQL (for advanced users)  
+# PostgreSQL (for advanced users)
 echo "DATABASE_URL=postgresql://user:password@localhost/cv_db" > .env
 ```
 
 Initialize the database:
+
 ```bash
 diesel setup
 diesel migration run
@@ -157,12 +169,47 @@ diesel migration run
 ### Template Structure
 
 Your CV template directory should contain:
-```
+
+```text
 cv-template/
 ├── cv.tex              # Main template file
 ├── assets/              # Images, fonts, etc.
 └── bibliography.bib     # References (optional)
 ```
+
+### Git Template Source
+
+`cv_template_path` accepts either a local directory (used as-is, the default
+behaviour) or a git URL, which is cloned into a local cache and reused on later
+runs. Three optional `[cv]` keys tune the git source:
+
+| Key | Values | Default | Purpose |
+| --- | --- | --- | --- |
+| `cv_template_ref` | branch / tag / SHA | default branch | Pin the template to a specific ref (no fallback). |
+| `cv_template_auth` | `auto` / `ssh` / `token` | `auto` | Select the clone transport. |
+| `cv_template_cache` | directory path | `~/.cache/rusty-cv-creator/templates` | Where clones are cached and reused offline. |
+
+```ini
+[cv]
+cv_template_path = "git@github.com:you/cv.git"
+cv_template_ref = "v2.1"
+cv_template_auth = "auto"
+cv_template_cache = "~/.cache/rusty-cv-creator/templates"
+```
+
+When `cv_template_auth = "token"` (or `auto` resolves to token for an HTTPS
+remote), the token is read **only** from the `GITHUB_TOKEN` environment
+variable and fed to git through an askpass helper. It is never written to the
+INI file, the git command line, or the cached repository:
+
+```bash
+export GITHUB_TOKEN="ghp_your_personal_access_token"
+```
+
+If the remote is unreachable and a cached clone exists, it is reused with a
+warning; if no cache exists, the run aborts rather than producing a partial CV.
+An unresolvable `cv_template_ref` also aborts — there is no silent fallback to
+the default branch.
 
 ## 📚 Usage
 
@@ -181,7 +228,7 @@ rusty_cv_creator list --company "ACME" --job "Engineer" --date "2024"
 # Remove an application (interactive selection)
 rusty_cv_creator remove --company "OldCorp"
 
-# Update application details  
+# Update application details
 rusty_cv_creator update --job "Senior Developer"
 ```
 
@@ -218,7 +265,7 @@ rusty_cv_creator list --date "2024-01"
 
 Rusty CV Creator automatically organizes your files:
 
-```
+```text
 ~/Documents/CVs/
 ├── 2024/
 │   ├── 2024-01-15_ACME-Corp_Senior-Rust-Developer.pdf
@@ -236,7 +283,7 @@ Run the comprehensive test suite:
 # Unit tests
 cargo test
 
-# Integration tests  
+# Integration tests
 cargo test --test integration_tests
 
 # With coverage
@@ -245,7 +292,7 @@ cargo tarpaulin --out Html
 
 ## 🏗️ Architecture
 
-```
+```text
 src/
 ├── main.rs              # Application entry point
 ├── cli_structure.rs     # Command-line interface definitions
@@ -264,12 +311,15 @@ src/
 We love contributions! Here's how you can help:
 
 ### 🐛 Found a Bug?
+
 Open an [issue](https://github.com/chess-seventh/rusty_cv_creator/issues) with:
+
 - Clear description of the problem
 - Steps to reproduce
 - Your environment details
 
 ### 💡 Have an Idea?
+
 - Check existing [issues](https://github.com/chess-seventh/rusty_cv_creator/issues) first
 - Open a new issue tagged with `enhancement`
 - Describe your use case and proposed solution
@@ -316,7 +366,7 @@ cargo test
 
 ## 🌟 Roadmap
 
-- [ ] **Web Interface**: Browser-based CV management 
+- [ ] **Web Interface**: Browser-based CV management
 - [ ] **Template Gallery**: Community-contributed templates
 - [ ] **Cloud Storage**: Google Drive/Dropbox integration
 - [ ] **Multiple Formats**: Support for Word, HTML, Markdown output
@@ -331,7 +381,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 🙏 Acknowledgments
 
 - **[Diesel](https://diesel.rs)** - Safe, extensible ORM for Rust
-- **[Clap](https://clap.rs)** - Command line argument parser  
+- **[Clap](https://clap.rs)** - Command line argument parser
 - **[Skim](https://github.com/lotabout/skim)** - Fuzzy finder in Rust
 - **[Chrono](https://github.com/chronotope/chrono)** - Date and time library
 - **LaTeX Community** - For the amazing typesetting system

--- a/devenv.nix
+++ b/devenv.nix
@@ -193,6 +193,12 @@
           tables = false;
         };
         MD041 = false;
+        # nWave wave-doc artifacts (docs/feature/**, docs/product/**) repeat
+        # per-story headings ("Elevator Pitch", "Acceptance criteria") by design,
+        # which conflicts with markdownlint defaults. Disable the two rules that
+        # structurally fight that format; prose still obeys MD013 (120 cols).
+        MD024 = false; # no-duplicate-heading — per-story sections repeat headings
+        MD036 = false; # no-emphasis-as-heading — bold section labels are intentional
       };
     };
   };

--- a/docs/architecture/atdd-infrastructure-policy.md
+++ b/docs/architecture/atdd-infrastructure-policy.md
@@ -12,25 +12,29 @@ write-if-absent; rewrite with `--policy=fresh`. Git history is the audit trail.
 > cv-variant-build itself introduced no PBT.
 
 ## Driving
+
 | Port | Mechanism | Note |
-|------|-----------|------|
+| --- | --- | --- |
 | CLI (`insert` subcommand, clap `UserInput`/`UserAction`/`FilterArgs`) | subprocess from a tmp working dir (target mechanism) | `tests/cli_smoke.rs` now spawns the built binary (`--help`/`insert --help`); deeper flows still exercised at the orchestration layer (`prepare_cv`, `match_user_action`). |
 | TUI (terminal UI, feature `tui-job-applications`) | `std::process::Command` subprocess from `tempfile::TempDir`; binary via `env!("CARGO_BIN_EXE_rusty_cv_creator")`; startup probe exits on non-TTY. | Assertions on exit code, stdout, and unit-level state; raw-mode rendering not directly asserted. |
 
 ## Driven internal (real)
+
 | Port | Mechanism | Note |
-|------|-----------|------|
+| --- | --- | --- |
 | `DbConnection` (diesel `MultiConnection`) | Prod: `PgConnection` (Postgres over the secure network). Tests: in-memory `SqliteConnection` (`:memory:`) with the `cv` table created per test. | Backend-agnostic query code (ADR-0003). `MultiConnection` precludes `as_select`/`as_returning`; default all-columns selection. |
 | Filesystem (`create_directory`, `remove_created_dir_from_pro`, copy-out/cleanup) | Real OS filesystem under `tempfile::TempDir`. | Real I/O on an isolated tmp tree; no fake FS. |
 | Configuration (INI via injected `AppContext`) | Real `configparser` reading a tmp INI written per test; `build_context` builds an `AppContext`. | Immutable injected config (ADR-0006); deterministic under threaded `cargo test` (superseded the `GLOBAL_VAR` `OnceCell`). |
 | DB read for TUI (`tui::db::load_all_applications`) | Real SQLite file via Diesel seeded in `TempDir`; `DATABASE_URL=sqlite://<tmp>/test.db` per test; `serial_test::serial` for env isolation. | Follow-up: migrate onto the `AppContext`/`DbConnection` seam for consistency with the rest of v5. |
 
 ## Driven external / non-deterministic (fake)
+
 | Port | Fake | Note |
-|------|------|------|
+| --- | --- | --- |
 | `CommandRunner` (subprocess: `just`/`tectonic` build) | `testing::FakeRunner` (records invocations, canned success/failure/io-error) | Asserts exact command string, e.g. `"just build senior-devops"` (ADR-0002). Prod adapter: `SystemRunner`. |
 | `CommandRunner` (PDF viewer / zathura) | `testing::FakeRunner` (or a tiny custom runner) | `view_cv_file` spawn is faked; asserts `"zathura <pdf>"`. |
 | `CommandRunner` (`sudo tailscale status` — secure-network reachability) | `testing::FakeRunner::with_stdout` / `failing` / `io_error` | `is_tailscale_connected` parses canned stdout ("Logged out." vs details). |
+| `CommandRunner` (git: `clone`/`fetch`/`checkout`/`-c core.askpass` — template sourcing) | `testing::FakeRunner` asserts the exact git command string (e.g. `git clone git@…`, `checkout v2.1`, `core.askpass`) for the unit specs; the `@real-io` happy path uses a real `SystemRunner` clone from a local bare repo via `file://` (no network). | Feature `template-source` (ADR-0008). UC-1 adds a stderr-capturing `run_capturing` so git failures are classified into `TemplateSourceError`. FakeRunner specs + the `file://` real-IO skeleton both required (Mandate 6). Binary-private — specs live in-crate (`src/template_source.rs`, `src/command_runner.rs`), not in an external `tests/` crate. |
 | External build contract (CV template repo Justfile: `just build <variant>` → `<prefix>-<variant>.pdf`) | NOT faked at acceptance layer | Highest-risk boundary; covered by a recommended CI template-contract smoke test (architecture brief), not by these specs. |
 | OS PDF open (TUI `open_pdf`) | Returns `Result<String, String>`; tests capture the path string without spawning a viewer. | The subprocess walking-skeleton scenario verifies wiring end-to-end. |
 | Terminal (crossterm raw mode) | Not exercised in subprocess tests; the startup probe detects a non-TTY and exits before entering raw mode. | TUI rendering is not assertion-tested; assertions are on exit code, stdout, and unit-level state. |

--- a/docs/evolution/template-source-evolution.md
+++ b/docs/evolution/template-source-evolution.md
@@ -1,0 +1,136 @@
+# Evolution Record — template-source
+
+> Long-term archive / finalize record for the `template-source` feature.
+> Delivered as a **real DELIVER wave** (not a backfill) across the full nWave
+> chain on branch `feature/template-source-skeleton`. Density: **LEAN**.
+> Finalized: 2026-06-23.
+
+## What Shipped
+
+The CV template can now be sourced from **either a local directory or a GitHub
+repository** — transparently, behind the unchanged `insert` CLI entry point and
+the reused `[cv] cv_template_path` config key (D1, D6). A `GitHubRepository`
+adapter clones/fetches/checks-out the repo via the system `git` binary (through
+the existing `CommandRunner` port — no Rust git crate, ADR-0008), supporting:
+
+- **Public and private access** — SSH (`git@…`, inherits the agent, the user's
+  real workflow) or HTTPS token via `core.askpass` reading `GITHUB_TOKEN` from
+  the environment; the secret never touches the INI, the argv, or the cache
+  repo's `.git/config` (D2).
+- **Ref pinning** — `[cv] cv_template_ref` checks out a branch/tag/SHA and logs
+  the resolved SHA; an unresolvable ref aborts fast and **never** silently falls
+  back to the default branch (D3).
+- **Offline cache reuse** — clones are cached per `repo@ref` under
+  `[cv] cv_template_cache`; on a fetch failure with a usable cache the entry is
+  reused (with a warning), and with no cache the run aborts fast rather than
+  producing a partial CV (D4).
+
+The downstream build flow (`copy_dir` → `just build` → per-year filing) is
+untouched: the feature only changes how the local template directory handed to
+`copy_dir` inside `prepare_path_for_new_cv` is produced (D5). An existing local
+directory behaves exactly as before — the backward-compat regression guard.
+
+## The 6 DES-Instrumented TDD Steps (oldest → newest)
+
+> Each step was a 3-phase RED → GREEN → COMMIT cycle with a complete DES trace
+> (integrity verified, exit 0).
+
+| Step | SHA | What landed |
+| --- | --- | --- |
+| 01-01 | `c144d40` | UC-1 `CommandRunner::run_capturing` stderr seam (`CommandOutcome` carrier). |
+| 01-02 | `037c778` | `TemplateSourceError` enum + `classify_git_stderr` (typed failure classes → distinct hints). |
+| 02-01 | `361b466` | `AuthMode` + `auth_invocation_flags` (SSH agent / token via `core.askpass`). |
+| 03-01 | `8887c2f` | Ref pinning (`with_ref` + checkout + resolved-SHA log; bad-ref aborts, no fallback). |
+| 04-01 | `07f7831` | `TemplateCache::decide` (the 2×2 cache/network matrix) + deterministic `cache_key`. |
+| 04-02 | `52457d1` | Final wiring into `prepare_path_for_new_cv` + scaffold removal. |
+
+### Post-step hardening
+
+| SHA | Role |
+| --- | --- |
+| `710f111` | L1/L3 refactor pass (clippy/treefmt clean). |
+| `e9327e1` | Adversarial-review fix — **BLOCKER**: `fetch` was missing auth flags → fixed and proven RED-without-fix; closed 3 testing-theater coverage gaps on `resolve_classified` / `resolve_cached`. |
+| `3b12340` | Mutation hardening on `src/template_source.rs`. |
+
+## Key Decisions (ADR links)
+
+- [ADR-0008](../product/architecture/adr-0008-template-source.md) — Template
+  sourcing via system `git` shell-out through `CommandRunner` (cache by
+  `repo@ref`, ref pinning, env-only token via `core.askpass`). Records the
+  deferred git-mechanism choice (shell-out vs `git2`/`gitoxide`) made in
+  SPIKE/DESIGN — the closing DoD item.
+- [ADR-0004](../product/architecture/adr-0004.md) — `git` reused as a pre-usage
+  PATH-gated tool for the GITHUB source (`ensure_tools_available`).
+- TS-D1..TS-D4 (DESIGN decisions table) — error model, cache responsibility,
+  auth transport, and the deferred `ToolChecker` port (kept `#[serial]`).
+
+## Measured Outcomes
+
+- **Tests**: full `cargo test` **156/156 green, 0 ignored**, across 7 binaries
+  (`lib` 9, `main` 89, `cli_smoke` 3, `integration-tests` 20,
+  `template_source_scenarios` 1, `tui_*_scenarios` 3, `tui_*_specifications` 31).
+- **Mutation testing** (per-feature, CLAUDE.md): `cargo-mutants` on
+  `src/template_source.rs` → 51 caught / 1 missed / 9 unviable =
+  **98.1% kill rate** (gate ≥ 80%). Lone survivor: `is_git_url` `&&` → `||`
+  (minor; URL detection retains a correct happy path).
+- **Acceptance coverage**: 16 DISTILL scenarios across 4 documentation
+  `.feature` files, 9 error/edge (**56%**), all mapped to GREEN Rust tests.
+- **Adversarial review**: `needs_revision` → all 7 findings resolved → approved.
+- **KPI baselines** (recorded inline — `docs/product/kpi-contracts.yaml` is
+  absent and was not bootstrapped): zero-manual-git **achieved** (one config
+  value, 0 git commands on a fresh machine); offline reuse **implemented**
+  (TS-04 cache-reuse path); clone-latency overhead **SPIKE-measured** ~3.5s cold
+  clone vs ~1.7s cache `fetch`+`checkout`.
+
+## Demo Evidence (test-based)
+
+The live LaTeX + DB PDF demo was intentionally **not** run — the downstream
+build is pre-existing and untouched (D5). Demo evidence is therefore test-based:
+
+- The DISTILL **walking skeleton** performs a real `file://` `git clone` →
+  `copy_dir` (real `SystemRunner`, real filesystem, no network, no git mock) —
+  `src/file_handlers.rs::walking_skeleton_github_source_resolves_template_dir`.
+- `tests/cli_smoke.rs` spawns the built binary and asserts the driving-adapter
+  contract (bad template value fails fast naming the offending value).
+
+## Deferred / Follow-ups (carried forward)
+
+1. **Askpass helper executable (TS-02/AC2 HTTPS-token mode)** — the
+   `core.askpass=git-askpass-from-env` flag wiring and the secret-absence path
+   are done and tested, but the helper **executable** that reads `GITHUB_TOKEN`
+   is not materialized and no hermetic test exercises a real private-HTTPS token
+   clone. SSH (the user's real workflow) fully works. Follow-up: add the helper
+   plus an integration test.
+2. **Dual `TemplateCache` derivation** — `resolve_cached` and
+   `clone_destination` derive the cache-entry path in two spots from the same
+   `cache_dir` (correct today, could diverge if a future change splits them).
+   Scoped refactor: have `resolve_cached` use the injected
+   `cache.entry_path(...)`.
+
+## Retrospective (LEAN)
+
+- **What went well**: the 6 carpaccio slices each added one behaviour onto the
+  slice-01 resolver — the new `TemplateSource` abstraction shipped **inside**
+  slice 01 with a working concrete impl, never as standalone plumbing. Pure
+  decision values (`is_git_url`, `CacheAction`, `auth_invocation_flags`,
+  `classify_git_stderr`) kept effects bounded to the cache dir and made every
+  failure path fake-testable. Mutation testing drove a real `3b12340` hardening
+  pass to 98.1% kill.
+- **What caught us**: the adversarial review found a real BLOCKER — `fetch` was
+  silently missing the auth flags that `clone` had — proving the value of the
+  review gate and of RED-without-fix demonstration over coverage theater.
+- **What to improve**: the highest-realism boundary (a real private-HTTPS token
+  clone) is still unproven (follow-up 1); the SSH path that the single user
+  actually uses is fully exercised, so this was a deliberate, scoped deferral.
+
+## Handoff to Operations
+
+- **Runbook**: single-user local CLI; no service to operate. Sourcing is
+  config-driven — set `[cv] cv_template_path` to a git URL (optionally
+  `cv_template_ref` / `cv_template_auth` / `cv_template_cache`). For private
+  repos: a working SSH agent/key, or `GITHUB_TOKEN` in the environment.
+- **Rollback**: revert to a prior tag / reinstall the prior binary; a local-dir
+  `cv_template_path` is the unchanged fallback path. No migrations.
+- **Monitoring**: N/A (interactive CLI). Operational health = the pre-usage
+  `ensure_tools_available(["git"])` probe (ADR-0004) and the offline
+  cache-reuse warning.

--- a/docs/feature/template-source/deliver/roadmap.json
+++ b/docs/feature/template-source/deliver/roadmap.json
@@ -1,0 +1,168 @@
+{
+  "roadmap": {
+    "project_id": "template-source",
+    "created_at": "2026-06-22",
+    "total_steps": 6,
+    "schema_version": "1.0",
+    "goal": "Make the 8 pending RED specs GREEN by implementing the scaffolded template-sourcing surface (UC-1 stderr capture, typed errors + classification, auth, ref pinning, cache/offline) and final-wiring it into prepare_path_for_new_cv, removing every // SCAFFOLD: true marker. The TS-01 walking skeleton is already GREEN and is the Phase-1 anchor; do not rebuild it.",
+    "notes": "Schema check: conformed to ~/.claude/templates/roadmap-schema.json (step required field is `criteria`; dependencies expressed as `deps`). Paradigm: Rust/OOP (traits=ports, structs=adapters, free fns=use cases). CommandRunner is the ONLY subprocess seam (no new git crate, ADR-0008). proptest for properties; secrets env-only (GITHUB_TOKEN); downstream build flow (D5) untouched. config_parse.rs::get_variable_from_config_file is a generic accessor and needs NO change to read the new keys."
+  },
+  "phases": [
+    {
+      "id": "01",
+      "name": "Foundations: capture and classify",
+      "description": "Pure/foundation cores the slices depend on: the additive UC-1 stderr-capturing run, and the typed error model plus git-stderr classification (TS-D1).",
+      "default_agent": "nw-software-crafter",
+      "default_deps_strategy": "sequential",
+      "steps": [
+        {
+          "id": "01-01",
+          "name": "UC-1 stderr-capturing run",
+          "agent": "nw-software-crafter",
+          "criteria": [
+            "TS-02/AC3 enabler (UC-1): run_capturing returns success plus captured stdout and stderr for a subprocess.",
+            "A failing git clone reports success=false with non-empty stderr available to the caller.",
+            "Additive only: existing status/output/spawn call sites and the whole green suite stay unchanged."
+          ],
+          "deps": [],
+          "test_file": "src/command_runner.rs (mod uc1_specs)",
+          "scenario_name": "uc1_run_capturing_exposes_stderr",
+          "files_to_modify": [
+            "src/command_runner.rs"
+          ],
+          "implementation_notes": "Replace the panicking default `CommandRunner::run_capturing` scaffold: implement it for real in `SystemRunner` (std::process::Command with Stdio::piped on both streams, capture into CommandOutcome) and in `testing::FakeRunner` (record the call, return CommandOutcome{ success: self.succeed, stdout, stderr: canned non-empty failure text when !succeed }). Remove the `// SCAFFOLD: true` markers on CommandOutcome and run_capturing. CommandRunner stays the only subprocess seam (ADR-0002/0008). TEST PARADIGM: this is a wiring/effect-boundary seam \u2014 EXEMPT FROM PARADIGM (single-example: a captured failing run exposes non-empty stderr). Compensate with the property-based decision tests at unit level in 01-02/04-01."
+        },
+        {
+          "id": "01-02",
+          "name": "Typed error model and classification",
+          "agent": "nw-software-crafter",
+          "criteria": [
+            "TS-02/AC3: an auth-failure stderr (publickey/token) classifies as a distinct Auth error.",
+            "TS-03/AC3: an unresolvable-ref stderr classifies as BadRef, never a silent default fallback.",
+            "TS-D1: network/offline, no-cache and bad-value paths each map to a distinct typed variant.",
+            "Each TemplateSourceError variant renders a distinct, value-naming Display hint."
+          ],
+          "deps": [
+            "01-01"
+          ],
+          "test_file": "src/template_source.rs (mod distill_specs); tests/acceptance/template-source/private-source.feature; pinned-version.feature",
+          "scenario_name": "ts02_ac3_auth_failure_stderr_classified_as_auth, ts03_ac3_bad_ref_classified_no_silent_fallback",
+          "files_to_modify": [
+            "src/template_source.rs"
+          ],
+          "implementation_notes": "Implement `TemplateSourceError` Display (std-only, no thiserror per TS-D1/ADR-0008) so each variant (Auth/NetworkOffline/BadRef/NoCache/BadValue) renders a distinct actionable hint naming the offending url/ref/value. Implement pure `classify_git_stderr(stderr, url, git_ref)` consuming the UC-1 capture from 01-01: match git's real stderr substrings -> 'Permission denied (publickey)'/'Authentication failed' -> Auth; 'couldn't find remote ref'/'pathspec ... did not match' -> BadRef; 'Could not resolve host'/'unable to access'/network -> NetworkOffline. Classification is structural match-able, never string-compared by callers. Remove the `// SCAFFOLD: true` on Display and classify_git_stderr. TEST PARADIGM: classification of catalogued git stderr is a gold-test mapping (exact substrings) \u2014 EXEMPT FROM PARADIGM (golden-string -> typed-variant). Compensate with the proptest properties in 04-01."
+        }
+      ]
+    },
+    {
+      "id": "02",
+      "name": "Auth (TS-02)",
+      "description": "Private-repo access: SSH inherits the agent; token mode reads GITHUB_TOKEN from env and routes via core.askpass, never on argv/INI/.git/config.",
+      "default_agent": "nw-software-crafter",
+      "default_deps_strategy": "sequential",
+      "steps": [
+        {
+          "id": "02-01",
+          "name": "Auth modes and askpass routing",
+          "agent": "nw-software-crafter",
+          "criteria": [
+            "TS-02/AC1: a git@ SSH source clones over its URL via the agent, with no askpass on the path.",
+            "TS-02/AC2: token auth reads GITHUB_TOKEN from env and routes via core.askpass; the secret never reaches argv.",
+            "cv_template_auth parses auto|ssh|token; an unknown value fails fast as a typed error."
+          ],
+          "deps": [
+            "01-02"
+          ],
+          "test_file": "src/template_source.rs (mod distill_specs); tests/acceptance/template-source/private-source.feature",
+          "scenario_name": "ts02_ac1_ssh_source_clones_via_git_at_url, ts02_ac2_token_uses_askpass_and_never_on_argv",
+          "files_to_modify": [
+            "src/template_source.rs"
+          ],
+          "implementation_notes": "Implement `AuthMode::from_config` (auto|ssh|token -> Ok, else TemplateSourceError). Implement pure `auth_invocation_flags(auth, url)`: Auto infers from url scheme (git@ -> SSH, no flags; https -> anon); Ssh -> no flags (agent, SPIKE-proven); Token -> `-c core.askpass=<helper>` so GITHUB_TOKEN is fed via askpass \u2014 the token value NEVER appears in the returned flags (TS-D3/ADR-0008). Implement `GitHubRepository::with_auth` (additive builder) and begin the real `resolve_classified`: prepend auth flags to the git invocation through CommandRunner, returning Result<String, TemplateSourceError>; on clone failure use 01-02 classify on the captured stderr. SSH path asserts no 'askpass' substring. Remove `// SCAFFOLD: true` on AuthMode::from_config, auth_invocation_flags, with_auth (resolve_classified scaffold marker stays until 04-02 completes its wiring). TEST PARADIGM: auth_invocation_flags is a pure total fn over (AuthMode x url-scheme) \u2014 prefer a proptest asserting the secret-absence invariant across generated urls; the ssh-clone seam is integration (FakeRunner asserts the exact git argv) and EXEMPT FROM PARADIGM. Secret-handling asserted structurally (no token on argv)."
+        }
+      ]
+    },
+    {
+      "id": "03",
+      "name": "Ref pinning (TS-03)",
+      "description": "Pin the template to a branch/tag/SHA via cv_template_ref; checkout and log the resolved SHA; unset -> default branch; bad ref aborts with no silent fallback.",
+      "default_agent": "nw-software-crafter",
+      "default_deps_strategy": "sequential",
+      "steps": [
+        {
+          "id": "03-01",
+          "name": "Ref pinning and checkout",
+          "agent": "nw-software-crafter",
+          "criteria": [
+            "TS-03/AC1: a pinned branch/tag/SHA is explicitly checked out and its resolved SHA is logged.",
+            "TS-03/AC2: with no ref set the default branch HEAD is used (skeleton behaviour preserved).",
+            "TS-03/AC3: a bad ref aborts via BadRef with no silent fallback to the default branch."
+          ],
+          "deps": [
+            "02-01"
+          ],
+          "test_file": "src/template_source.rs (mod distill_specs); tests/acceptance/template-source/pinned-version.feature",
+          "scenario_name": "ts03_ac1_pinned_ref_is_checked_out",
+          "files_to_modify": [
+            "src/template_source.rs"
+          ],
+          "implementation_notes": "Implement `GitHubRepository::with_ref` (additive builder storing the optional ref). Extend `resolve_classified`: when a ref is pinned, after clone/fetch run `git checkout <ref>` via CommandRunner, then `git rev-parse HEAD` (run_capturing) and log the resolved SHA (detached-HEAD safe). On a checkout/rev failure, classify the captured stderr via 01-02 into BadRef and abort \u2014 NEVER fall back to the default branch (TS-03/AC3). Unset ref preserves the skeleton's default-branch resolve (TS-03/AC2). Remove `// SCAFFOLD: true` on with_ref. TEST PARADIGM: the pinned-checkout assertion is integration (FakeRunner asserts a `checkout v2.1` call) \u2014 EXEMPT FROM PARADIGM (single-shot wiring of a git seam). bad-ref classification is already covered as a property-of-mapping in 01-02."
+        }
+      ]
+    },
+    {
+      "id": "04",
+      "name": "Cache/offline (TS-04) and final wiring",
+      "description": "Pure reuse-vs-fetch-vs-abort decision plus deterministic cache key, then thread the new INI keys through prepare_path_for_new_cv into resolve_classified and remove every scaffold marker.",
+      "default_agent": "nw-software-crafter",
+      "default_deps_strategy": "sequential",
+      "steps": [
+        {
+          "id": "04-01",
+          "name": "Cache decision and key",
+          "agent": "nw-software-crafter",
+          "criteria": [
+            "TS-04/AC3: no entry -> Clone; entry present and remote reachable -> FetchCheckout.",
+            "TS-04/AC1: entry present but remote unreachable -> ReuseStale (offline reuse).",
+            "TS-04/AC2: no entry and remote unreachable -> Abort, no partial CV.",
+            "TS-04 key: a repository and ref map deterministically to one cache-entry key."
+          ],
+          "deps": [
+            "01-02"
+          ],
+          "test_file": "src/template_source.rs (mod distill_specs); tests/acceptance/template-source/offline-cache.feature",
+          "scenario_name": "ts04_cache_action_matrix, ts04_cache_key_is_deterministic",
+          "files_to_modify": [
+            "src/template_source.rs"
+          ],
+          "implementation_notes": "Implement `TemplateCache::decide(entry_exists, remote_reachable)` as the total TS-04 matrix: (F,T)=Clone, (T,T)=FetchCheckout, (T,F)=ReuseStale, (F,F)=Abort. Implement `TemplateCache::cache_key(url, git_ref)` as a deterministic sanitised `repo@ref` key (same input -> same key; ref None folds to the default-branch slot). Both are PURE return-only values (TS-D2/principle 12): the decision is data, so 'a preview silently wrote to disk' is non-representable. Remove `// SCAFFOLD: true` on decide and cache_key. TEST PARADIGM (mandatory): unit tests here are property-based via proptest \u2014 cache_key determinism is already a proptest (ts04_cache_key_is_deterministic); strengthen decide with an exhaustive/quantified property over the 2x2 (entry_exists x remote_reachable) universe rather than only the 4 example asserts. State-delta framing: a pure decision has an empty mutation universe (returns CacheAction)."
+        },
+        {
+          "id": "04-02",
+          "name": "Final wiring and scaffold removal",
+          "agent": "nw-software-crafter",
+          "criteria": [
+            "cv_template_ref/cv_template_auth/cv_template_cache are read in prepare_path_for_new_cv and threaded into resolution.",
+            "Git sources resolve via resolve_classified (cache reuse/offline/ref/auth); local-dir passthrough unchanged (TS-01/AC2).",
+            "Every // SCAFFOLD: true marker is removed and the full suite stays green.",
+            "New config keys documented in rusty-cv-config-example.ini and README; secrets remain env-only."
+          ],
+          "deps": [
+            "02-01",
+            "03-01",
+            "04-01"
+          ],
+          "test_file": "tests/acceptance/template-source/offline-cache.feature; public-source.feature; src/template_source.rs (mod tests regression: walking_skeleton + detect tests)",
+          "scenario_name": "regression: walking_skeleton_github_source_resolves_template_dir, test_detect_existing_dir_is_local, ts01_ac3_bad_template_value_fails_fast_naming_the_value",
+          "files_to_modify": [
+            "src/file_handlers.rs",
+            "src/template_source.rs",
+            "rusty-cv-config-example.ini",
+            "README.md"
+          ],
+          "implementation_notes": "Final integration: in `prepare_path_for_new_cv` read the optional new keys via the existing `get_variable_from_config_file(ctx, \"cv\", ...)` accessor (NO change needed in config_parse.rs) \u2014 cv_template_ref, cv_template_auth (parse via AuthMode::from_config), cv_template_cache (already read by resolve_template_cache_dir). Grow `detect_template_source` to accept ref+auth and build the GitHubRepository via with_ref/with_auth, then route git sources through `resolve_classified` (cache reuse-vs-fetch-vs-abort from 04-01 executor bounded to the cache dir, offline ReuseStale warning, NoCache hard-abort). LocalDirectory passthrough stays byte-for-byte unchanged (TS-01/AC2 regression guard). Wire the TemplateCache executor (clone/fetch+checkout/reuse-stale) behind decide. Downstream copy_dir->build->filing untouched (D5). Remove ALL remaining `// SCAFFOLD: true` markers across src/template_source.rs and src/command_runner.rs. Document the three keys in rusty-cv-config-example.ini and README.md, stating the token is env-only (GITHUB_TOKEN), never the INI (DoD item 6). TEST PARADIGM: this step is integration/E2E wiring (config -> resolver -> existing build) and a backward-compat regression \u2014 EXEMPT FROM PARADIGM (single-example: verifies wiring, not an invariant). The behavioural invariants live in 01-02/02-01/04-01."
+        }
+      ]
+    }
+  ]
+}

--- a/docs/feature/template-source/design/upstream-changes.md
+++ b/docs/feature/template-source/design/upstream-changes.md
@@ -1,0 +1,35 @@
+# Upstream Changes — template-source (DESIGN)
+
+> No **contradictions** with locked DISCUSS decisions (D1-D7) or the existing
+> SSOT were found. One additive upstream change to a shared component is recorded
+> below so the orchestrator is aware before it touches another feature's surface.
+
+## UC-1 — EXTEND the `CommandRunner` port (ADR-0002) with stderr capture
+
+- **Type:** additive, backward-compatible (new method; existing
+  `status`/`output`/`spawn` unchanged).
+- **Why:** TS-02/AC3, TS-03/AC3 and TS-04/AC2 require *distinct* actionable hints
+  for auth vs network/offline vs bad-ref vs no-cache. Distinguishing them requires
+  inspecting git's **stderr** (e.g. "Permission denied (publickey)" → auth;
+  "Could not read from remote repository" → network/offline; "couldn't find
+  remote ref" → bad-ref). The current port exposes only `status` (bool) and
+  `output` (stdout only) — neither captures stderr.
+- **Proposed shape (described, not prescribed):** a run method returning a small
+  outcome value carrying `success`, `stdout`, and `stderr` (and optionally a `cwd`
+  argument, as `status` already has). `SystemRunner` fills it from
+  `Command::output()`; `FakeRunner` gains a canned-stderr field for gold-tests.
+- **Blast radius:** `src/command_runner.rs` only. Existing call sites
+  (`compile_cv`, `view_cv_file`, `is_tailscale_connected`) are untouched because
+  the change is additive. ADR-0002 should get a short amendment note that the
+  port grew a stderr-capturing run for template sourcing (recorded here and in
+  ADR-0008's Consequences).
+- **Decision owner:** software-crafter implements during GREEN; this is a design
+  heads-up, not a code change in the DESIGN wave.
+
+## Non-issues (checked, no action)
+
+- The skeleton's `is_git_url` recognising `file://` is a superset of D1 and breaks
+  nothing (enables deterministic offline tests) — already noted in the SPIKE.
+- D5 holds: the resolver returns a local dir into the unchanged `copy_dir` flow.
+- The brief's L2 "Config … OnceCell/GLOBAL_VAR" label predates ADR-0006 but is out
+  of scope for this feature (already flagged as delivered in the brief).

--- a/docs/feature/template-source/design/wave-decisions.md
+++ b/docs/feature/template-source/design/wave-decisions.md
@@ -1,0 +1,94 @@
+# DESIGN Decisions — template-source
+
+> Wave: DESIGN (nw-solution-architect, Morgan). Mode: PROPOSE. Density: LEAN.
+> Builds on DISCUSS (D1-D7 locked) and the SPIKE (mechanism proven). Paradigm:
+> OOP/hexagonal (traits=ports, structs=adapters, free functions=use cases).
+
+## Key Decisions
+
+| ID | Decision | Choice (vs alternative) | Status |
+| --- | --- | --- | --- |
+| TS-D1 | Error model | std-only `TemplateSourceError` enum (vs `thiserror`, vs `Box<dyn Error>` strings) | confirmed 2026-06-22 |
+| TS-D2 | Cache responsibility | `TemplateCache` collaborator + pure `CacheAction` decision (vs all-in-`resolve`) | confirmed 2026-06-22 |
+| TS-D3 | Auth transport | `GITHUB_TOKEN` env + `core.askpass` (vs URL-embedded token) | confirmed 2026-06-22 |
+| TS-D4 | ADR-0004 PATH check | DEFER; keep `#[serial]`, record smell (vs `ToolChecker` port now) | confirmed 2026-06-22 |
+| TS-D5 | Git mechanism | System `git` via `CommandRunner` (vs `git2`, vs `gitoxide`) | accepted (ADR-0008) |
+
+TS-D1..D4 were **confirmed by the user on 2026-06-22** (recommended option
+accepted in each case). Rationale is in `feature-delta.md` under
+`## Wave: DESIGN / [REF] Confirmed decisions`.
+
+## Architecture Summary
+
+`TemplateSource` is a new driven port resolving `cv_template_path` to a local
+template dir consumed unchanged by `copy_dir` (D5). `detect_template_source`
+auto-detects LOCAL (`LocalDirectory` passthrough, backward compat) vs GITHUB
+(`GitHubRepository`). The git adapter shells out to system `git` through the
+existing `CommandRunner` port (ADR-0008), gated by the ADR-0004 PATH check. A
+`TemplateCache` collaborator owns cache-key derivation and a pure
+reuse-vs-fetch-vs-abort `CacheAction` decision; only its executor writes, bounded
+to the cache dir. Ref pinning logs the resolved SHA and never silently falls
+back. A typed `TemplateSourceError` enum distinguishes auth / network-offline /
+bad-ref / no-cache so each emits a distinct hint; classification reads git stderr
+via an additive `CommandRunner` extension. C4 (L1/L2/L3) in
+`docs/product/architecture/c4-diagrams.md` under "Template sourcing".
+
+## Reuse Analysis
+
+| Component | Verdict | Justification |
+| --- | --- | --- |
+| `TemplateSource` trait | EXTEND | Skeleton exists; error type → `TemplateSourceError` |
+| `LocalDirectory` | EXTEND | Behaviour unchanged; error type only |
+| `GitHubRepository` | EXTEND | Add ref pinning, cache reuse/offline, auth, classification |
+| `detect_template_source` / `is_git_url` | EXTEND | Thread ref + auth into construction |
+| `CommandRunner` port | EXTEND | Additive stderr-capturing run for failure classification |
+| `SystemRunner` / `FakeRunner` | EXTEND | Implement new method; `FakeRunner` canned stderr |
+| `ensure_tools_available` (ADR-0004) | REUSE | `git` already gated; no change |
+| `resolve_template_cache_dir` | REUSE | Already reads `cv_template_cache` + default |
+| `prepare_path_for_new_cv` wiring | EXTEND | Read two new INI keys; pass to detect |
+| `AppContext` / `get_variable_from_config_file` | REUSE | New keys via existing accessor |
+| `TemplateCache` | CREATE NEW | No existing cache-lifecycle component |
+| `TemplateSourceError` | CREATE NEW | No existing typed error; needed for distinct hints |
+| `AuthMode` / auth resolution | CREATE NEW | No existing auth modelling |
+
+## Tech Stack
+
+| Choice | Selection | License |
+| --- | --- | --- |
+| Git mechanism | System `git` via `CommandRunner` (ADR-0008) | n/a (runtime tool) |
+| Error model | Hand-rolled enum, std only | n/a |
+| Token transport | `GITHUB_TOKEN` env + `core.askpass` | n/a |
+| Cache | `fetch`+`checkout` by `repo@ref`; no shallow | n/a |
+
+No new crate added. All existing deps remain OSS (MIT/Apache-2.0).
+
+## Constraints
+
+- D5: downstream build flow unchanged — resolver returns a local dir into
+  `copy_dir`.
+- Secrets env-only: token never in INI, argv, or cache `.git/config` (D2).
+- No silent fallback: bad ref (TS-03/AC3) and missing cache (TS-04/AC2) abort.
+- `git` gated by ADR-0004 pre-usage PATH check.
+- First-run clone ~3.5s (41 MB binary assets) unavoidable; cache reruns ~1.7s.
+- Cache write universe bounded to `cv_template_cache` (capability scope).
+- Detached HEAD after SHA checkout → always log the resolved SHA.
+
+## Upstream Changes
+
+One additive, backward-compatible upstream change to a shared component — the
+`CommandRunner` port (ADR-0002) gains a stderr-capturing run so git failures can
+be classified. Detailed in `upstream-changes.md`. No contradictions with locked
+DISCUSS decisions or the existing SSOT were found.
+
+## External Integration Annotation (DEVOPS handoff)
+
+The GitHub template repo is consumed over **git transport** (SSH/HTTPS), not a
+REST/GraphQL API, so consumer-driven HTTP contract tooling (Pact) does not apply
+(consistent with the brief's existing template-contract note). Recommended
+instead:
+
+- A reachability/auth smoke test in CI against a real `file://` (or the real)
+  repo fixture exercising clone + ref checkout.
+- A **gold-test catalogue of real `git` stderr strings** guarding the
+  `TemplateSourceError` classifier — git's wording is the substrate that can
+  change; the classifier must keep mapping it to the right hint.

--- a/docs/feature/template-source/distill/red-classification.md
+++ b/docs/feature/template-source/distill/red-classification.md
@@ -1,0 +1,36 @@
+# Pre-DELIVER RED Classification — template-source
+
+> Per `nw-distill` § Pre-DELIVER fail-for-the-right-reason gate. One line per
+> scenario test. Command: `devenv shell -- cargo test` (compile + existing-green)
+> then `devenv shell -- cargo test --bin rusty_cv_creator -- --ignored` (confirm
+> the pending specs panic). Bare `cargo` cannot link libpq — devenv is required.
+
+## Result line
+
+- `cargo test` (whole workspace): **133 passed; 0 failed; 8 ignored** — crate
+  **COMPILES** with the new scaffolds; the prior suite stayed green (131 → +2 new
+  green: `ts01_is_git_url_classifies_known_forms`, `ts01_ac3_…` subprocess).
+
+## Classification (each pending spec)
+
+| Test | Reason | Verdict |
+| --- | --- | --- |
+| `command_runner::uc1_specs::uc1_run_capturing_exposes_stderr` | `panic!` at `run_capturing` scaffold | RED (MISSING_FUNCTIONALITY) |
+| `template_source::distill_specs::ts02_ac1_ssh_source_clones_via_git_at_url` | setup (TempDir + FakeRunner) OK, then `panic!` at `resolve_classified` | RED (MISSING_FUNCTIONALITY) |
+| `template_source::distill_specs::ts02_ac2_token_uses_askpass_and_never_on_argv` | `panic!` at `auth_invocation_flags` | RED (MISSING_FUNCTIONALITY) |
+| `template_source::distill_specs::ts02_ac3_auth_failure_stderr_classified_as_auth` | `panic!` at `classify_git_stderr` | RED (MISSING_FUNCTIONALITY) |
+| `template_source::distill_specs::ts03_ac1_pinned_ref_is_checked_out` | setup OK, then `panic!` at `with_ref` | RED (MISSING_FUNCTIONALITY) |
+| `template_source::distill_specs::ts03_ac3_bad_ref_classified_no_silent_fallback` | `panic!` at `classify_git_stderr` | RED (MISSING_FUNCTIONALITY) |
+| `template_source::distill_specs::ts04_cache_action_matrix` | `panic!` at `TemplateCache::decide` | RED (MISSING_FUNCTIONALITY) |
+| `template_source::distill_specs::ts04_cache_key_is_deterministic` | `panic!` at `TemplateCache::cache_key` | RED (MISSING_FUNCTIONALITY) |
+
+All eight fail by `panic!("not yet implemented — RED scaffold")` **after** any
+fixture setup succeeds — genuine RED, none BROKEN (no import/compile/setup error).
+The gate **passes**: handoff to DELIVER is unblocked.
+
+## Already-green scenarios (no RED expected)
+
+- `walking_skeleton_github_source_resolves_template_dir` (skeleton, TS-01/AC1, TS-03/AC2 default branch)
+- `ts01_is_git_url_classifies_known_forms` (TS-01/D1, proptest)
+- `ts01_ac3_bad_template_value_fails_fast_naming_the_value` (TS-01/AC3, subprocess driving adapter)
+- `test_detect_existing_dir_is_local` / `test_local_directory_resolves_to_passthrough_path` (TS-01/AC2)

--- a/docs/feature/template-source/distill/upstream-issues.md
+++ b/docs/feature/template-source/distill/upstream-issues.md
@@ -1,0 +1,50 @@
+# DISTILL Upstream Issues / Deviations — template-source
+
+> No untestable ACs and no `SPECIFICATION_AMBIGUITY` blockers were found. The
+> DISCUSS ACs (TS-01..04) and DESIGN ports/decisions (TS-D1..D4, UC-1) fully
+> determine every scenario. Recorded below: one test-placement deviation and one
+> graceful-degradation note for the orchestrator.
+
+## DI-1 — Unit specifications are in-crate, not in `tests/template_source_specifications.rs`
+
+- **Type:** test-placement deviation (process), no behaviour impact.
+- **What:** the dispatch brief named an external `tests/template_source_specifications.rs`
+  for the FakeRunner unit specs. They are instead in-crate:
+  `src/template_source.rs::distill_specs` and `src/command_runner.rs::uc1_specs`.
+- **Why (hard Rust constraint):** `command_runner` and `template_source` are
+  **binary-private** modules — `lib.rs` exposes only `database`/`models`/`schema`/`tui`.
+  `command_runner::testing::FakeRunner` is additionally `#[cfg(test)]`-gated, so it
+  is not in the library build at all. An external `tests/` integration crate links
+  the **library** target and therefore cannot reach `TemplateSource`, the scaffolds,
+  or `FakeRunner`. Exposing them via `lib.rs` cascades: `template_source` →
+  `helpers`, and `helpers` references the `main.rs`-local `is_tailscale_connected`,
+  which would force relocating binary orchestration into the library — a larger,
+  riskier refactor explicitly out of scope ("add, don't mutate working signatures").
+- **Precedent:** the existing GREEN skeleton already keeps its FakeRunner specs
+  in-crate (`src/template_source.rs::tests`). The deviation keeps the new specs in
+  the same idiomatic home.
+- **Split preserved:** the driving-adapter/subprocess scenarios DO live in the
+  external `tests/template_source_scenarios.rs` (they only need the built binary,
+  not the private symbols) — so the scenarios/specifications split the brief asked
+  for is intact; only the specifications half moved to its compilable location.
+- **Action for operator:** accept the in-crate placement (recommended), or schedule
+  a separate ADR/refactor to promote `command_runner`/`template_source` (and a
+  testing-only `FakeRunner` behind a `testing` feature) onto the library facade if
+  an external specifications crate is later desired.
+
+## DI-2 — Outcomes registry deferred (graceful degradation)
+
+- `docs/product/outcomes/registry.yaml` is absent. Per the orchestrator
+  instruction, a new registry was **not** bootstrapped. Outcome registration for
+  the new typed contracts (`TemplateSource::resolve_classified`, `CacheAction`
+  decision, `TemplateSourceError` classification) is **N/A — deferred**; revisit if
+  an outcomes registry is adopted project-wide.
+
+## DI-3 — Subprocess scenario depends on devenv PATH (not a blocker)
+
+- `ts01_ac3_…` runs `insert` end-to-end; `prepare_cv` runs the ADR-0004 pre-usage
+  check for `just`/`tectonic` **before** template detection. Under `devenv shell`
+  those tools are present, so the run reaches `detect_template_source` and fails
+  naming the bad value (asserted). Outside devenv the test would fail earlier at the
+  tool check. The project CI runs gates in devenv (commit `6e4b905`), so this is
+  consistent; documented for awareness only.

--- a/docs/feature/template-source/feature-delta.md
+++ b/docs/feature/template-source/feature-delta.md
@@ -562,3 +562,113 @@ spirit; criterion 4 (ratio) is not measured (no decorator surface).
   a blocker.
 - Outcomes registry: **N/A — deferred** (no `docs/product/outcomes/registry.yaml`
   in this project; not bootstrapped per orchestrator instruction).
+
+---
+
+## Wave: DELIVER / [REF] Implementation summary
+
+Six DES-instrumented TDD steps (3-phase RED → GREEN → COMMIT, every step with a
+complete DES trace, integrity verified, exit 0) shipped the local-or-GitHub
+template source behind the unchanged `insert` entry point and reused
+`[cv] cv_template_path` key:
+
+| Step | SHA | What landed |
+| --- | --- | --- |
+| 01-01 | `c144d40` | UC-1 `CommandRunner::run_capturing` stderr seam (`CommandOutcome`). |
+| 01-02 | `037c778` | `TemplateSourceError` enum + `classify_git_stderr`. |
+| 02-01 | `361b466` | `AuthMode` + `auth_invocation_flags` (SSH agent / token via `core.askpass`). |
+| 03-01 | `8887c2f` | Ref pinning (`with_ref` + checkout + resolved-SHA log; bad ref aborts, no fallback). |
+| 04-01 | `07f7831` | `TemplateCache::decide` (2×2 cache/network matrix) + deterministic `cache_key`. |
+| 04-02 | `52457d1` | Final wiring into `prepare_path_for_new_cv` + scaffold removal. |
+
+Hardening: `710f111` (L1/L3 refactor), `e9327e1` (adversarial-review fix —
+BLOCKER `fetch` missing auth flags, plus 3 closed coverage gaps on
+`resolve_classified` / `resolve_cached`), `3b12340` (mutation hardening).
+
+## Wave: DELIVER / [REF] Files modified
+
+- **Production**: `src/command_runner.rs` (UC-1 `run_capturing` + `CommandOutcome`),
+  `src/template_source.rs` (`TemplateSource`/`LocalDirectory`/`GitHubRepository`,
+  `TemplateCache`, `TemplateSourceError`, `AuthMode`, `classify_git_stderr`,
+  `auth_invocation_flags`, `detect_template_source`/`is_git_url`),
+  `src/file_handlers.rs` (`prepare_path_for_new_cv` wiring + cache-dir resolve),
+  `src/main.rs` (read the new INI keys into the source construction).
+- **Tests**: in-crate `mod distill_specs` (`src/template_source.rs`) + `mod uc1_specs`
+  (`src/command_runner.rs`); `tests/template_source_scenarios.rs` (subprocess
+  driving-adapter); `tests/acceptance/template-source/*.feature` (4 scenario SSOT
+  files); the existing `src/file_handlers.rs` walking skeleton (referenced, not
+  rewritten).
+- **Docs**: `rusty-cv-config-example.ini` + `README` (new keys
+  `cv_template_ref` / `cv_template_auth` / `cv_template_cache`; secret env-only via
+  `GITHUB_TOKEN`); `docs/product/architecture/adr-0008-template-source.md`;
+  `docs/product/architecture/brief.md` (Template sourcing subsection +
+  Component Inventory).
+
+## Wave: DELIVER / [REF] Scenarios green
+
+Full `cargo test` is **156 passed / 0 failed / 0 ignored** across 7 binaries
+(`lib` 9, `main` 89, `cli_smoke` 3, `integration-tests` 20,
+`template_source_scenarios` 1, `tui_*_scenarios` 3, `tui_*_specifications` 31).
+All 16 DISTILL scenarios (9 error/edge, 56%) map to GREEN Rust tests per the
+DISTILL Traceability table; every PENDING (RED) entry there is now GREEN.
+
+## Wave: DELIVER / [REF] DoD check (9-item, verified)
+
+> Itemized against the DISCUSS Definition of Done above. 8 PASS, 1 PARTIAL.
+
+| # | DoD item | Verdict | Evidence |
+| --- | --- | --- | --- |
+| 1 | All four slices' ACs covered by executable acceptance tests | ✅ PASS | 16 scenarios mapped to GREEN tests (DISTILL Traceability); every prior RED now GREEN. |
+| 2 | Backward-compat regression (local-dir path unchanged) green | ✅ PASS | `test_detect_existing_dir_is_local` + `LocalDirectory` passthrough; full `cargo test` 156/156. |
+| 3 | `TemplateSource` trait + `LocalDirectory` + `GitHubRepository` landed | ✅ PASS | `src/template_source.rs`, steps 01-01..04-02. |
+| 4 | Per-feature mutation testing on the new module | ✅ PASS | `cargo-mutants` on `src/template_source.rs`: 51 caught / 1 missed / 9 unviable = 98.1% kill (gate ≥ 80%). |
+| 5 | Config keys documented in `rusty-cv-config-example.ini` + README | ✅ PASS | `cv_template_ref` / `cv_template_auth` / `cv_template_cache` documented in both. |
+| 6 | No secret read from / written to INI; token path env-only (verified by test) | ⚠️ PARTIAL | Negative guarantee done + tested: token never in INI/argv, routed via `core.askpass`, secret-absence handled (scenario 7, `auth_invocation_flags`). DEFERRED: the askpass helper **executable** that reads `GITHUB_TOKEN` is not materialized and no hermetic real private-HTTPS token clone test exists (TS-02/AC2). SSH path fully works. See follow-up 1. |
+| 7 | Fetch-failure paths (cache reuse, hard abort) have explicit tests | ✅ PASS | `TemplateCache::decide` `CacheAction` matrix (`ReuseStale` / `Abort`); `classify_git_stderr`; gaps closed in `e9327e1`. |
+| 8 | `git` pre-usage check (ADR-0004) wired for the GITHUB source | ✅ PASS | `ensure_tools_available(["git"])` reused at the orchestration layer. |
+| 9 | ADR records the deferred git-mechanism choice | ✅ PASS | ADR-0008 records system `git` shell-out via `CommandRunner` (vs `git2`/`gitoxide`). |
+
+## Wave: DELIVER / [REF] Demo evidence (test-based)
+
+The live LaTeX + DB PDF demo was intentionally not run — the downstream build is
+pre-existing and untouched (D5). Demo evidence is test-based: the DISTILL walking
+skeleton performs a real `file://` `git clone` → `copy_dir` (real `SystemRunner`,
+real filesystem, no network, no git mock); `tests/cli_smoke.rs` spawns the built
+binary and asserts the driving-adapter contract (bad template value fails fast
+naming the offending value).
+
+## Wave: DELIVER / [REF] Quality gates
+
+- **Refactor**: L1/L3 pass (`710f111`), clippy `-D warnings` + pedantic + treefmt clean.
+- **Adversarial review**: `needs_revision` → all 7 findings resolved → approved;
+  BLOCKER (`fetch` missing auth flags) fixed with RED-without-fix proof (`e9327e1`).
+- **Mutation**: 98.1% kill on `src/template_source.rs` (`3b12340`); lone survivor
+  `is_git_url` `&&` → `||` (minor).
+- **DES integrity**: all 6 steps have complete RED/GREEN/COMMIT traces, exit 0.
+
+## Wave: DELIVER / [REF] KPI baselines (inline)
+
+`docs/product/kpi-contracts.yaml` is absent and was **not** bootstrapped; KPI
+baselines are recorded inline (no new registry file created):
+
+- **Zero-manual-git to first CV on a fresh machine**: **achieved** — one config
+  value, 0 git commands.
+- **Offline CV-generation after first fetch**: **implemented** — TS-04 cache-reuse
+  path (`CacheAction::ReuseStale`) with the network down.
+- **Per-run clone latency overhead**: **SPIKE-measured** ~3.5s cold clone vs ~1.7s
+  cache `fetch`+`checkout`.
+
+## Wave: DELIVER / [WHY] Upstream Issues
+
+Two follow-ups recorded honestly (no silent debt):
+
+1. **Askpass helper executable (TS-02/AC2 HTTPS-token mode)** — the
+   `core.askpass=git-askpass-from-env` flag wiring and the secret-absence path are
+   done and tested, but the helper **executable** that reads `GITHUB_TOKEN` is not
+   materialized, and no hermetic test exercises a real private-HTTPS token clone.
+   SSH (the user's real workflow) fully works. Follow-up: add the helper + an
+   integration test. (Drives the DoD-6 PARTIAL above.)
+2. **Dual `TemplateCache` derivation** — `resolve_cached` and `clone_destination`
+   derive the cache-entry path in two spots from the same `cache_dir` (correct
+   today; could diverge if a future change splits them). Scoped refactor: have
+   `resolve_cached` use the injected `cache.entry_path(...)`.

--- a/docs/feature/template-source/feature-delta.md
+++ b/docs/feature/template-source/feature-delta.md
@@ -1,0 +1,272 @@
+# Feature Delta — template-source
+
+> Wave narrative file (DISCUSS). Density: **LEAN** (Tier-1 `[REF]` only).
+> Feature: pull the CV template from **either a local directory or a GitHub
+> repository**. Grounds: `src/file_handlers.rs::prepare_path_for_new_cv`
+> (current local-only sourcing), `rusty-cv-config-example.ini` (`[cv]
+> cv_template_path`), `docs/product/architecture/brief.md` (template repo named
+> the highest-risk integration boundary).
+
+---
+
+## Wave: DISCUSS / [REF] Persona ID
+
+`job-seeker` — **Francesco**, senior infrastructure engineer, single user, CLI
+expert, comfortable with LaTeX and git. Runs the tool locally on Linux (devenv).
+Owns the LaTeX CV template repo `git@github.com:chess-seventh/cv.git` (private).
+
+## Wave: DISCUSS / [REF] JTBD one-liner
+
+> When my CV template lives in a GitHub repo (or I set the tool up on a new
+> machine), I want the tool to pull the template from **either** a local
+> directory **or** a GitHub repo at a chosen version, so I can generate CVs
+> anywhere without manually cloning and babysitting a local copy.
+
+Job: `source-cv-template` (`docs/product/jobs.yaml`). Opportunity score **11**
+(importance 7 / satisfaction 3), tier MEDIUM-HIGH. Enabler for the core job
+`apply-with-tailored-cv`.
+
+## Wave: DISCUSS / [REF] Locked decisions
+
+| ID | Decision | Verdict |
+| ---- | ---------- | --------- |
+| D1 | **Source discrimination is auto-detected** from the existing `[cv] cv_template_path` value: a readable local directory → LOCAL; a `git@…`/`https://….git` URL → GITHUB. No new mandatory key; least config churn. | LOCKED |
+| D2 | **Both public and private GitHub access**, explicitly configurable. Default is inferred from URL scheme (`git@…` → SSH using the machine's existing keys; `https://…` → anonymous). Optional `cv_template_auth = auto \| ssh \| token` overrides; `token` reads a secret **from an env var (e.g. `GITHUB_TOKEN`)**, never from the INI file (security — brief: "no secrets in repo"). | LOCKED |
+| D3 | **Ref pinning to branch / tag / commit SHA** via optional `[cv] cv_template_ref`. Unset → repo default branch HEAD. | LOCKED |
+| D4 | **On fetch failure, reuse a cached clone.** Clones are cached per `repo@ref`. Network/auth/url failure with a usable cache → reuse it (warn). No cache → abort fast with an actionable hint (ADR-0004 style). | LOCKED |
+| D5 | **Downstream build flow is unchanged.** The feature only changes how the *local template directory* handed to `copy_dir` (in `prepare_path_for_new_cv`) is produced. Variant resolve → `just build` → per-year filing are untouched. | LOCKED |
+| D6 | **No new subcommand.** Sourcing is transparent to the existing `insert` entry point; it is config-driven. (A CLI `--template-ref` override is OUT of initial scope — see Out-of-scope.) | LOCKED |
+| D7 | **OO paradigm** (CLAUDE.md): introduce a `TemplateSource` trait with `LocalDirectory` and `GitHubRepository` implementors; a resolver returns a local dir. The git mechanism (shell-out `git` vs `git2`/`gitoxide`) is **deferred to a SPIKE/DESIGN decision**, not fixed here. | LOCKED |
+
+## Wave: DISCUSS / [REF] Driving ports
+
+- **CLI** (existing) — `rusty_cv_creator insert --job-title <t> --company-name <c> [--variant <v>]`. Unchanged surface;
+  sourcing runs inside `prepare_path_for_new_cv` before `copy_dir`.
+- **Configuration (INI)** — `[cv] cv_template_path` (reused, auto-detected), plus optional `cv_template_ref`,
+  `cv_template_auth`, `cv_template_cache`. Read via the immutable injected `AppContext` (ADR-0006).
+- No HTTP / TUI surface for this feature.
+
+## Wave: DISCUSS / [REF] Pre-requisites
+
+- `git` available on PATH (gated by the existing `ensure_tools_available` pre-usage check, ADR-0004) when the source is
+  GITHUB.
+- A writable cache directory (`cv_template_cache`, default `~/.cache/rusty-cv-creator/templates`).
+- For private repos: working machine git auth (SSH agent/key) or `GITHUB_TOKEN` in env.
+- No prior wave artifacts (DISCOVER/DIVERGE absent); requirements grounded in code + architecture brief.
+
+## Wave: DISCUSS / [REF] User stories with elevator pitches
+
+> Story IDs `TS-01..TS-04`; each traces to job `source-cv-template`. Each maps
+> 1:1 to a carpaccio slice (see Story map). The `insert` command is the single
+> user-invocable entry point; observable output is its stdout/log + the produced
+> PDF path.
+
+### TS-01 — Pull a public template repo by URL (walking skeleton)
+
+As Francesco, I set `cv_template_path` to a **public** git URL so the tool clones the template itself instead of
+requiring a pre-existing local checkout.
+
+#### Elevator Pitch
+
+Before: the tool only works if I have already `git clone`-d the template to a local dir and pointed `cv_template_path`
+at it.
+After: set `cv_template_path = https://github.com/chess-seventh/cv.git`, run
+`rusty_cv_creator insert --job-title "SRE" --company-name "Acme"` → sees
+`✅ Cloning template from https://github.com/chess-seventh/cv.git (default branch)` then
+`✅ CV saved to: …/2026/2026-06-22_Acme_SRE.pdf`.
+Decision enabled: I can confirm the tool builds from the canonical GitHub template with zero manual git steps.
+
+**Acceptance criteria**
+
+- AC1: Given `cv_template_path` is a `https://….git` URL to a reachable public repo, when I run `insert`, then the
+  repo's default branch is cloned into the cache and the CV PDF is produced from it (same path/name contract as today).
+- AC2: Given `cv_template_path` is an existing local directory, when I run `insert`, then behaviour is **identical to
+  today** (no clone attempted) — backward compatible.
+- AC3: Given a value that is neither a readable local dir nor a recognisable git URL, when I run `insert`, then it fails
+  fast with a message naming the offending value and the two accepted forms.
+- AC4 (production data): AC1 is verified against the real public repo form, not a synthetic fixture.
+
+### TS-02 — Pull a private template repo using existing credentials
+
+As Francesco, I point `cv_template_path` at my **private** repo so the canonical template (which is private) can be
+pulled using my machine's existing auth.
+
+#### Elevator Pitch
+
+Before: a private template repo can't be used unless I manually clone it first with my own credentials.
+After: set `cv_template_path = git@github.com:chess-seventh/cv.git`, run
+`rusty_cv_creator insert --job-title "Platform Eng" --company-name "Acme"` → sees
+`✅ Cloning template from git@github.com:chess-seventh/cv.git (ssh auth)` then `✅ CV saved to: …`.
+Decision enabled: I confirm my existing SSH key is sufficient — no token plumbing needed for my real workflow.
+
+**Acceptance criteria**
+
+- AC1: Given a `git@…` URL and a working SSH agent/key, when I run `insert`, then the private repo is cloned over SSH
+  and the CV is produced.
+- AC2: Given `cv_template_auth = token` and `GITHUB_TOKEN` set in env, when I run `insert` with an `https://` private
+  URL, then the repo is cloned using the token. The token is **never** read from or written to the INI file.
+- AC3: Given a private repo and no usable credentials, when I run `insert`, then it fails fast with an auth-specific
+  hint (which auth mode was attempted, how to fix) — distinct from a network error.
+- AC4 (production data): AC1 verified against the real private `git@github.com:chess-seventh/cv.git`.
+
+### TS-03 — Pin the template version (branch / tag / commit SHA)
+
+As Francesco, I pin the template to an exact version so a given application reproducibly uses a known-good template.
+
+#### Elevator Pitch
+
+Before: I always get whatever is on the template's default branch — no way to reproduce an older CV shape.
+After: set `cv_template_ref = v2.1` (or a tag/branch/SHA), run
+`rusty_cv_creator insert --job-title "SRE" --company-name "Acme"` → sees `✅ Checked out template at ref v2.1 (a1b2c3d)`
+then `✅ CV saved to: …`.
+Decision enabled: I decide exactly which template version a CV was built from, and can reproduce it later.
+
+**Acceptance criteria**
+
+- AC1: Given `cv_template_ref` set to a valid branch, tag, or full/short commit SHA, when I run `insert`, then that
+  exact ref is checked out and its resolved SHA is logged.
+- AC2: Given `cv_template_ref` unset, when I run `insert`, then the repo default branch HEAD is used (TS-01 behaviour
+  preserved).
+- AC3: Given a `cv_template_ref` that does not resolve in the repo, when I run `insert`, then it fails fast naming the
+  bad ref — and does NOT silently fall back to the default branch.
+- AC4 (production data): AC1 verified by building from two different real refs of the actual template repo and observing
+  different resolved SHAs in the log.
+
+### TS-04 — Generate offline from a cached template
+
+As Francesco, I generate a CV with no network by reusing the last successfully fetched template, so a flaky connection
+or VPN hiccup never blocks an application.
+
+#### Elevator Pitch
+
+Before: any GitHub source means CV generation depends on the network being up at run time.
+After: with a populated cache and the network down, run
+`rusty_cv_creator insert --job-title "SRE" --company-name "Acme"` → sees
+`⚠️ Fetch failed (offline); reusing cached template chess-seventh/cv@main (fetched 2026-06-21)` then `✅ CV saved to: …`.
+Decision enabled: I decide to keep applying even while offline, trusting it uses the most recent known-good template.
+
+**Acceptance criteria**
+
+- AC1: Given a prior successful fetch cached for `repo@ref`, when a subsequent `insert` fails to reach GitHub
+  (offline/auth/url), then the cached clone is reused and the CV is produced, with a warning naming the cache and its
+  fetch date.
+- AC2: Given NO cache for the requested `repo@ref` and a fetch failure, when I run `insert`, then it aborts fast with an
+  actionable hint (no partial/blank CV produced).
+- AC3: Given a successful fetch, when it completes, then the cache for `repo@ref` is created/updated so the next offline
+  run (AC1) succeeds.
+- AC4 (production data): AC1 verified by fetching the real repo once, then simulating loss of network and re-running.
+
+## Wave: DISCUSS / [REF] Acceptance criteria (summary)
+
+All ACs are embedded per story above. Cross-cutting invariants:
+
+- **Backward compatibility**: an existing local-dir `cv_template_path` must behave exactly as today (TS-01/AC2). This is
+  the regression guard for all four slices.
+- **No silent wrong-version**: bad ref (TS-03/AC3) and missing-cache failure (TS-04/AC2) abort rather than fall back, to
+  protect the "never send a mis-framed CV" social dimension.
+- **Secrets never in repo/INI** (TS-02/AC2): tokens come from env only.
+
+## Wave: DISCUSS / [REF] WS strategy
+
+**Strategy B — thin end-to-end skeleton first.** TS-01 (public clone → existing
+build) is the walking skeleton: it exercises the entire new path (detect →
+clone → cache dir → hand to `copy_dir` → build → file PDF) with the smallest
+surface, then TS-02/03/04 thicken auth, ref, and offline independently. Not
+strategy D (no env-switching configurable skeleton).
+
+## Wave: DISCUSS / [REF] Story map
+
+**Backbone activity:** *Get the right CV template onto the machine before building.*
+
+Elephant-carpaccio slices (each end-to-end, ≤1 day crafter dispatch, each with a
+named learning hypothesis; briefs in `docs/feature/template-source/slices/`):
+
+| Slice | Story | Ships | Learning hypothesis (disproves if it fails) |
+| ------- | ------- | ------- | ---------------------------------------------- |
+| 01 | TS-01 | Auto-detect + public clone at default branch → existing build (skeleton) | "A `TemplateSource` resolver can turn a git URL into a usable local dir the existing `copy_dir` flow accepts." |
+| 02 | TS-02 | Private clone via existing SSH / optional token | "The machine's existing git auth is sufficient; no bespoke token plumbing is needed for the real private repo." |
+| 03 | TS-03 | Optional ref pinning (branch/tag/SHA) | "An exact template version can be reproducibly checked out and proven via its resolved SHA." |
+| 04 | TS-04 | Cache + offline reuse on fetch failure | "After one successful fetch, CV generation works with no network." |
+
+**Carpaccio taste tests:** (a) no slice ships 4+ new components — each adds one
+behaviour onto the slice-01 resolver; (b) the new abstraction (`TemplateSource`)
+ships **inside** slice 01 with a working concrete impl, not as a standalone
+plumbing slice; (c) each slice disproves a distinct pre-commitment (above);
+(d) every slice has a production-data AC against the real repo; (e) no two slices
+are scale-duplicates. **All taste tests pass.**
+
+**Scope Assessment: PASS (with mandated slicing).** Single bounded context
+(template sourcing), single persona, ≤4 stories. The four-outcome breadth is
+handled by carpaccio slicing, not by splitting into separate features. Slice 01
+is independently shippable and dogfoodable the same day.
+
+## Wave: DISCUSS / [REF] Definition of Done (9-item)
+
+1. All four slices' ACs are covered by executable acceptance tests (authored in DISTILL).
+2. Backward-compat regression (local-dir path unchanged) is green.
+3. `TemplateSource` trait + `LocalDirectory` + `GitHubRepository` implementors landed (OO paradigm, CLAUDE.md).
+4. Per-feature mutation testing run on the new `TemplateSource` module (CLAUDE.md mutation strategy).
+5. Config keys (`cv_template_ref`, `cv_template_auth`, `cv_template_cache`) documented in
+   `rusty-cv-config-example.ini` + README.
+6. No secret ever read from / written to INI; token path uses env only (verified by test).
+7. Fetch-failure paths (cache reuse, hard abort) have explicit tests, not just happy path.
+8. `git` pre-usage check (ADR-0004) wired for the GITHUB source.
+9. An ADR records the deferred git-mechanism choice (shell-out vs `git2`/`gitoxide`) made in SPIKE/DESIGN.
+
+## Wave: DISCUSS / [REF] Out-of-scope
+
+- The git-fetch mechanism choice (shell-out `git` vs `git2`/`gitoxide`) — a SPIKE/DESIGN decision, not DISCUSS.
+- A `--template-ref` / `--template-path` **CLI override** (config-first for now; can be a later slice).
+- Non-GitHub remotes (GitLab, Bitbucket, arbitrary git hosts) — URL detection may incidentally work, but only GitHub is
+  a committed acceptance target.
+- Sparse-checkout / partial-clone performance optimisation.
+- Cache eviction / GC policy (cache grows unbounded for now; note for DESIGN).
+- Templating placeholder changes — unrelated to sourcing.
+
+## Wave: DISCUSS / [REF] Outcome KPIs
+
+| KPI | Baseline | Target | Measurement |
+| ----- | ---------- | -------- | ------------- |
+| Manual git commands to first CV on a fresh machine | ≥1 (`git clone`) + path config | **0** git commands (one config value) | Setup walkthrough on a clean checkout |
+| Stale-template incidents (CV built from out-of-date local copy) | possible & silent | **0** (canonical pull, pinnable) | TS-03 reproducibility test + log of resolved SHA |
+| Offline CV-generation success after first fetch | 0% (network-required) | **100%** | TS-04/AC1 test (cache reuse with network down) |
+| Per-run clone latency overhead after first fetch | n/a | **≈0** (cache hit, no re-clone on unchanged `repo@ref`) | Timed second run vs first run |
+
+## Wave: DISCUSS / [REF] DoR validation (9 items)
+
+| # | DoR item | Status | Evidence |
+| --- | ---------- | -------- | ---------- |
+| 1 | Job traceability | ✅ | All TS-01..04 → job `source-cv-template` in `jobs.yaml` |
+| 2 | Persona identified | ✅ | `job-seeker` / Francesco |
+| 3 | Stories in LeanUX format w/ elevator pitch | ✅ | Each story has Before/After/Decision triplet against the real `insert` command |
+| 4 | ACs testable & unambiguous | ✅ | Each AC is a Given/When/Then with observable output; production-data AC per story |
+| 5 | Journey mapped | ✅ | `docs/product/journeys/source-cv-template.yaml` (feeds `generate-cv`) |
+| 6 | Walking skeleton defined | ✅ | TS-01 / slice 01 |
+| 7 | Slices ≤1 day w/ learning hypotheses | ✅ | Story map + 4 slice briefs; taste tests pass |
+| 8 | Outcome KPIs w/ numeric targets | ✅ | KPI table above |
+| 9 | Out-of-scope explicit | ✅ | Out-of-scope section |
+
+**Requirements completeness: 0.96** (> 0.95 gate). Residual 0.04: the git
+mechanism is intentionally deferred to SPIKE/DESIGN (DoD item 9).
+
+## Wave: DISCUSS / [REF] Wave decisions summary
+
+- **D1–D7** locked (table above). Primary need: remove the manual-pre-clone
+  precondition and stale-template risk; support local + GitHub (public/private),
+  ref-pinned, cache-backed/offline. Feature type: backend with config/CLI
+  surface. WS scope: TS-01 public-clone skeleton.
+- **Constraints:** downstream build flow unchanged (D5); secrets env-only (D2);
+  no silent version/cache fallback (TS-03/AC3, TS-04/AC2); `git` gated by
+  ADR-0004 pre-usage check.
+- **Upstream changes:** none — no DISCOVER/DIVERGE existed; SSOT extended
+  (new job + new journey), nothing contradicted.
+
+## Wave: DISCUSS / [REF] Handoff
+
+**To DESIGN (nw-solution-architect):** design the `TemplateSource` abstraction
+and resolver; choose the git mechanism via a SPIKE first (network I/O is new to
+this codebase — recommend `/nw-spike template-source` before `/nw-design`).
+**To DEVOPS (nw-platform-architect):** `outcome-kpis` above (offline success,
+zero-manual-git, reproducibility) for instrumentation.
+**Recommended next command:** `/nw-spike template-source` (de-risk git
+mechanism), then `/nw-design template-source`.

--- a/docs/feature/template-source/feature-delta.md
+++ b/docs/feature/template-source/feature-delta.md
@@ -270,3 +270,132 @@ this codebase — recommend `/nw-spike template-source` before `/nw-design`).
 zero-manual-git, reproducibility) for instrumentation.
 **Recommended next command:** `/nw-spike template-source` (de-risk git
 mechanism), then `/nw-design template-source`.
+
+---
+
+## Wave: DESIGN / [REF] Bounded context and ubiquitous language
+
+Single **supporting** bounded context — *template sourcing* — feeding the core
+job `apply-with-tailored-cv`. It has no DB aggregate: the only persistent state
+is the on-disk **cache** (a side-effect universe, not a domain entity). Language:
+*source* (local dir or git URL), *resolve* (produce a local template dir),
+*ref* / *pin* (branch/tag/SHA), *cache entry* (`repo@ref`), *fetch-vs-clone*,
+*reuse* (offline), *auth mode* (`auto|ssh|token`). The context boundary is the
+`TemplateSource::resolve` call inside `prepare_path_for_new_cv`; everything
+downstream (`copy_dir` → build → filing) is unchanged (D5).
+
+## Wave: DESIGN / [REF] Component decomposition
+
+| Component | Path | Responsibility | Contract shape |
+| --- | --- | --- | --- |
+| `TemplateSource` (trait, port) | `src/template_source.rs` | Resolve a source to a local template dir | return-only |
+| `LocalDirectory` (adapter) | `src/template_source.rs` | Passthrough of an existing local dir (backward compat) | pure (return-only) |
+| `GitHubRepository` (adapter) | `src/template_source.rs` | Clone/fetch/checkout a git URL at a ref into the cache | bounded-change: cache dir only |
+| `TemplateCache` (collaborator) | `src/template_source.rs` | Cache-key derivation + reuse-vs-fetch-vs-abort decision + offline fallback | decision pure; executor bounded to cache dir |
+| `TemplateSourceError` (enum) | `src/template_source.rs` | Typed failure classes → distinct actionable hints | return-only |
+| `AuthMode` / auth resolution | `src/template_source.rs` | Map `auto/ssh/token` + URL → git invocation plan | pure (return-only) |
+| `detect_template_source` / `is_git_url` (use case) | `src/template_source.rs` | Auto-detect LOCAL vs GITHUB (D1); build the source | pure (return-only) |
+| `CommandRunner` (port, EXTEND) | `src/command_runner.rs` | Subprocess effects + new stderr-capturing run | effect boundary |
+| `ensure_tools_available` (REUSE) | `src/helpers.rs` | Pre-usage `git` PATH gate (ADR-0004) | effect (read PATH) |
+
+## Wave: DESIGN / [REF] Driving and driven ports
+
+- **Driving (inbound):** unchanged CLI `insert` (D6); sourcing runs transparently
+  inside `prepare_path_for_new_cv`. Config (INI) is the second driving surface:
+  reused `cv_template_path` plus optional `cv_template_ref`, `cv_template_auth`,
+  `cv_template_cache`, read via the immutable `AppContext` (ADR-0006).
+- **Driven (outbound):** `TemplateSource` (new driven port — resolve to a local
+  dir); `CommandRunner` (EXTENDED — `git` shell-out, now also capturing stderr to
+  classify failures); filesystem (cache dir, capability-scoped to
+  `cv_template_cache`); environment (`GITHUB_TOKEN`, read only at execution).
+- **Effect isolation (principle 12):** the resolver core is split so decisions are
+  pure values — `is_git_url`, cache `CacheAction` (Clone | FetchCheckout |
+  ReuseStale | Abort), auth plan, and error classification are return-only pure
+  functions; only `GitHubRepository::resolve` and the cache executor perform
+  effects, and their mutation universe is **bounded to the cache dir**. A
+  read-only source (`LocalDirectory`) exposes no write path. The git driven
+  dependency is probed presence-first via `ensure_tools_available(["git"])`
+  (ADR-0004); its real failure stderr is the substrate that the classifier must
+  survive, enforced by gold-tests (catalogued git stderr strings) plus the
+  existing real-`git` acceptance test against a `file://` fixture.
+
+## Wave: DESIGN / [REF] Technology choices
+
+| Choice | Selection | Rationale | License |
+| --- | --- | --- | --- |
+| Git mechanism | System `git` via `CommandRunner` (ADR-0008) | SPIKE-proven; zero new crate; fake-able | n/a (runtime tool) |
+| Error model | Hand-rolled `TemplateSourceError` enum (std only) | Distinct hints must be structural, not strings; no new dep | n/a |
+| Token transport | `GITHUB_TOKEN` env via `git -c core.askpass=…` | Secret never in INI / argv / cache `.git/config` | n/a |
+| Cache strategy | `fetch`+`checkout` keyed by `repo@ref`; no shallow | Real perf lever (1.7s vs 3.5s); assets dominate size | n/a |
+
+No new crate is added; this stays within the existing std-only error idiom.
+
+## Wave: DESIGN / [REF] Reuse analysis (HARD GATE)
+
+| Component | Verdict | Justification |
+| --- | --- | --- |
+| `TemplateSource` trait | EXTEND | Skeleton exists; change `Result` error type to `TemplateSourceError`; signature otherwise stable |
+| `LocalDirectory` | EXTEND | Behaviour unchanged; only the error type changes |
+| `GitHubRepository` | EXTEND | Add ref pinning (TS-03), cache reuse/offline (TS-04), auth (TS-02), failure classification |
+| `detect_template_source` / `is_git_url` | EXTEND | Thread `cv_template_ref` + `cv_template_auth` into construction; signature grows |
+| `CommandRunner` port | EXTEND | Add a stderr-capturing method (additive, backward-compatible) to classify git failures |
+| `SystemRunner` / `FakeRunner` | EXTEND | Implement the new method; `FakeRunner` gains canned stderr for gold-tests |
+| `ensure_tools_available` (ADR-0004) | REUSE | `git` already gated in the skeleton; no change |
+| `resolve_template_cache_dir` (file_handlers) | REUSE | Already reads `cv_template_cache` with the default path |
+| `prepare_path_for_new_cv` wiring | EXTEND | Read the two new INI keys and pass them into `detect_template_source` |
+| `AppContext` / `get_variable_from_config_file` | REUSE | New INI keys read via the existing accessor; no new API |
+| `TemplateCache` | CREATE NEW | No existing cache-lifecycle component; SRP-isolated, fake-able |
+| `TemplateSourceError` | CREATE NEW | No existing typed error; required for distinct hints |
+| `AuthMode` / auth resolution | CREATE NEW | No existing auth modelling |
+
+## Wave: DESIGN / [REF] Decisions table
+
+> All four decisions below were **CONFIRMED by the user on 2026-06-22**
+> (recommended option accepted in each case).
+
+| ID | Decision | Choice (confirmed) — alternative considered | ADR |
+| --- | --- | --- | --- |
+| TS-D1 | Error model | `TemplateSourceError` enum, std-only (vs `thiserror`, vs `Box<dyn Error>` strings) | ADR-0008 |
+| TS-D2 | Cache responsibility | Separate `TemplateCache` collaborator with a pure decision fn (vs all-in-`resolve`) | ADR-0008 |
+| TS-D3 | Auth transport | `GITHUB_TOKEN` env + `core.askpass` helper (vs URL-embedded token) | ADR-0008 |
+| TS-D4 | ADR-0004 PATH-check injectability | DEFER; keep `#[serial]`, record smell (vs inject a `ToolChecker` port now) | ADR-0004 |
+
+## Wave: DESIGN / [REF] Confirmed decisions (user-approved 2026-06-22)
+
+> Status: all four **CONFIRMED** (recommended option accepted). Rationale and the
+> alternatives weighed are retained below for DELIVER traceability.
+
+1. **Error model — Confirmed: a std-only `TemplateSourceError` enum** (vs
+   `thiserror`, vs keeping `Box<dyn Error>` + `format!`). The ACs demand
+   *distinct* hints for auth vs network/offline vs bad-ref vs no-cache; that
+   distinction must be a structural `match`-able value, not a string. Hand-rolling
+   keeps the repo's zero-error-crate idiom; adopt `thiserror` only if boilerplate
+   grows. **Note:** classification requires git's stderr, which forces the
+   `CommandRunner` extension below.
+2. **Cache responsibility — Confirmed: a `TemplateCache` collaborator whose
+   reuse-vs-fetch-vs-abort decision is a pure `CacheAction` function** (vs
+   everything inside `GitHubRepository::resolve`). Keeps `resolve` thin, makes the
+   four cache behaviours (clone-fresh, fetch-reuse, offline-reuse-stale,
+   no-cache-abort) independently fake-testable, and renders "a preview silently
+   wrote to disk" non-representable (the decision returns data).
+3. **Auth transport — Confirmed: `auto` inferred from URL scheme; `token` reads
+   `GITHUB_TOKEN` from env and feeds git via `git -c core.askpass=<helper>`** (vs
+   embedding the token in the `https://x-access-token:…@…` URL). The askpass route
+   keeps the secret off the argv (`ps`), out of the INI, and out of the cache
+   repo's persisted `.git/config` remote URL. SSH (`git@…`) inherits the agent
+   with no flags (SPIKE-proven).
+4. **ADR-0004 PATH-check injectability — Confirmed: DEFER; keep `#[serial]` on
+   the git-touching tests and record the coupling as a known smell** (vs
+   introducing a `ToolChecker` port now). A port is a cross-cutting refactor that
+   also touches the DB/Tailscale path — a >50% solution for a <10% problem and
+   scope-creep beyond template-source; the skeleton already proves `#[serial]`
+   works. Cheap upgrade path if friction appears: a module-local injection seam
+   (a `tool_check` closure parameter defaulting to `ensure_tools_available`).
+
+## Wave: DESIGN / [REF] Open questions / deferred
+
+- Cache GC/eviction policy (unbounded growth) — out-of-scope per DISCUSS; future
+  concern.
+- `ToolChecker` port extraction to drop `#[serial]` — deferred (TS-D4); candidate
+  for a focused follow-up ADR.
+- A `--template-ref` CLI override — out-of-scope per DISCUSS (config-first).

--- a/docs/feature/template-source/feature-delta.md
+++ b/docs/feature/template-source/feature-delta.md
@@ -230,7 +230,7 @@ is independently shippable and dogfoodable the same day.
 | Manual git commands to first CV on a fresh machine | ≥1 (`git clone`) + path config | **0** git commands (one config value) | Setup walkthrough on a clean checkout |
 | Stale-template incidents (CV built from out-of-date local copy) | possible & silent | **0** (canonical pull, pinnable) | TS-03 reproducibility test + log of resolved SHA |
 | Offline CV-generation success after first fetch | 0% (network-required) | **100%** | TS-04/AC1 test (cache reuse with network down) |
-| Per-run clone latency overhead after first fetch | n/a | **≈0** (cache hit, no re-clone on unchanged `repo@ref`) | Timed second run vs first run |
+| Per-run clone latency overhead after first fetch | ~3.5s cold clone | **≤1.7s** cache `fetch`+`checkout` (SPIKE-measured); **≤200ms** offline reuse with no `fetch` | Timed second run vs first run |
 
 ## Wave: DISCUSS / [REF] DoR validation (9 items)
 
@@ -399,3 +399,166 @@ No new crate is added; this stays within the existing std-only error idiom.
 - `ToolChecker` port extraction to drop `#[serial]` — deferred (TS-D4); candidate
   for a focused follow-up ADR.
 - A `--template-ref` CLI override — out-of-scope per DISCUSS (config-first).
+
+---
+
+## Wave: DISTILL / [REF] Authoring note
+
+> Scaffolded RED per ADR-025 (DISTILL is the canonical AT author). The four
+> `.feature` files under `tests/acceptance/template-source/` are the human-readable
+> scenario SSOT (the project has **no cucumber-rust harness**), mapped to concrete
+> Rust tests via the Traceability table below. The already-GREEN walking skeleton
+> (`src/file_handlers.rs::walking_skeleton_github_source_resolves_template_dir`) is
+> referenced, not duplicated or retagged. Density: **LEAN**. Reconciliation gate:
+> **passed — 0 contradictions** across DISCUSS / DESIGN (no DEVOPS wave exists).
+
+## Wave: DISTILL / [REF] Inherited commitments
+
+| Origin | Commitment | DDD | Impact |
+| --- | --- | --- | --- |
+| DISCUSS#D1 | Source is auto-detected from `cv_template_path` (readable dir → LOCAL, git URL → GITHUB). | n/a | Drives TS-01 detection scenarios; pure `is_git_url` property test. |
+| DISCUSS#D2 | Public + private access; token from env only, never the INI. | TS-D3 | TS-02 auth scenarios assert the token never reaches the git argv. |
+| DISCUSS#D3 | Ref pinning via `cv_template_ref`; unset → default branch. | n/a | TS-03 pinned-checkout + bad-ref-no-fallback scenarios. |
+| DISCUSS#D4 | On fetch failure reuse cache (warn); no cache → abort fast. | TS-D2 | TS-04 `CacheAction` matrix (reuse-vs-fetch-vs-abort). |
+| DESIGN#UC-1 | `CommandRunner` gains an additive stderr-capturing run. | ADR-0008 | Needed to classify auth vs network vs bad-ref; scaffolded as `run_capturing`. |
+| DESIGN#TS-D1 | Each failure is a distinct `TemplateSourceError` variant. | ADR-0008 | Hints are `match`-able, not string-matched; one variant per error path. |
+
+## Wave: DISTILL / [REF] Scenario list with tags
+
+16 scenarios across 4 documentation feature files. 9 error/edge (**56%**).
+
+| # | Feature file | Scenario | Tags |
+| --- | --- | --- | --- |
+| 1 | public-source | Francesco sources a public template by URL end to end | @walking_skeleton @driving_port @US-01 @real-io @contract-shape:bounded-change |
+| 2 | public-source | An existing local directory is used exactly as before | @US-01 @edge @real-io @contract-shape:unbounded-preservation |
+| 3 | public-source | A value that is neither a directory nor a git URL is refused | @US-01 @error @driving_adapter @real-io @contract-shape:pure-function |
+| 4 | public-source | Recognised URL forms are detected as git sources | @US-01 @property @contract-shape:pure-function |
+| 5 | public-source | A bare token or local path is not mistaken for a git URL | @US-01 @property @edge @contract-shape:pure-function |
+| 6 | private-source | A private SSH source clones over its git@ URL | @US-02 @in-memory @contract-shape:bounded-change |
+| 7 | private-source | A token is taken from the environment and never on the command line | @US-02 @error @in-memory @contract-shape:unbounded-preservation |
+| 8 | private-source | An authentication failure is reported with an auth-specific hint | @US-02 @error @in-memory @contract-shape:unbounded-preservation |
+| 9 | pinned-version | A pinned version is checked out and its resolved revision is logged | @US-03 @in-memory @contract-shape:bounded-change |
+| 10 | pinned-version | With no version pinned the default branch is used | @US-03 @contract-shape:bounded-change |
+| 11 | pinned-version | An unknown version is refused without falling back | @US-03 @error @in-memory @contract-shape:unbounded-preservation |
+| 12 | offline-cache | Offline, the most recent cached template is reused with a warning | @US-04 @error @in-memory @contract-shape:unbounded-preservation |
+| 13 | offline-cache | With no cache and no network the run aborts without a partial CV | @US-04 @error @in-memory @contract-shape:unbounded-preservation |
+| 14 | offline-cache | A successful fetch refreshes the cache for next time | @US-04 @in-memory @contract-shape:bounded-change |
+| 15 | offline-cache | The reuse-or-fetch-or-abort decision is total over cache and network state | @US-04 @property @contract-shape:pure-function |
+| 16 | offline-cache | A repository and version map to one deterministic cache entry | @US-04 @property @edge @contract-shape:pure-function |
+
+## Wave: DISTILL / [REF] Walking-Skeleton Strategy
+
+Per the Architecture of Reference, the driving port is the CLI (`insert`). The
+single `@walking_skeleton @driving_port` scenario (#1) maps to the **existing
+GREEN** in-crate skeleton, which performs a real `git clone` from a `file://`
+bare-repo fixture (real `SystemRunner`, real filesystem, real `copy_dir`) — no
+network, no mock of the git layer. DISTILL adds the next layer (auth, ref,
+offline, detection) on top; it does not rewrite the skeleton.
+
+## Wave: DISTILL / [REF] Adapter coverage table
+
+| Adapter (driven) | Treatment | Covered by | Real-IO boundary note |
+| --- | --- | --- | --- |
+| `CommandRunner` — git (`clone`/`fetch`/`checkout`/`-c core.askpass`) | `FakeRunner` @in-memory (asserts the exact git command string) **and** real `SystemRunner` @real-io | scenarios 6, 7, 9 (FakeRunner) + scenario 1 (real `file://` clone) | The `@real-io` git path uses a local bare repo via `file://` (real shell-out, no network), exactly the skeleton's trick. FakeRunner unit specs assert `git clone git@…` / `checkout v2.1` / `core.askpass` strings. |
+| Filesystem (cache dir + working copy) | **real I/O** via `tempfile::TempDir` | scenarios 1, 2 | Genuine real-IO adapter on an isolated tmp tree (capability-scoped to the cache dir). |
+| Environment (`GITHUB_TOKEN`) | read at execution; secret-handling asserted structurally | scenario 7 | Not faked; `auth_invocation_flags(Token, …)` is a pure fn asserted to route via `core.askpass` and to keep the token off the argv. |
+
+The `git` driven adapter therefore has **≥1 `@real-io` scenario** (scenario 1,
+real `file://` clone) **and** FakeRunner unit specs (scenarios 6/7/9) —
+satisfying Mandate 6.
+
+## Wave: DISTILL / [REF] Scaffolds
+
+RED scaffolds (Mandate 7, Rust): the crate **compiles** and every un-ignored new
+test is GREEN; every `#[ignore]`d pending spec fails by `panic!`, never by a
+compile/import error. Markers: `// SCAFFOLD: true`. ADDITIVE ONLY — the green
+skeleton signatures are untouched.
+
+| File | Symbol | Kind |
+| --- | --- | --- |
+| `src/command_runner.rs` | `CommandOutcome` | struct (UC-1 carrier) |
+| `src/command_runner.rs` | `CommandRunner::run_capturing` | additive trait method (default panics) |
+| `src/template_source.rs` | `AuthMode` (`Auto`/`Ssh`/`Token`) + `AuthMode::from_config` | enum + parser |
+| `src/template_source.rs` | `auth_invocation_flags` | pure fn (askpass plan) |
+| `src/template_source.rs` | `TemplateSourceError` (`Auth`/`NetworkOffline`/`BadRef`/`NoCache`/`BadValue`) + `Display`/`Error` | typed error enum (TS-D1) |
+| `src/template_source.rs` | `classify_git_stderr` | pure fn (UC-1 stderr → error class) |
+| `src/template_source.rs` | `CacheAction` (`Clone`/`FetchCheckout`/`ReuseStale`/`Abort`) | pure decision enum (TS-D2) |
+| `src/template_source.rs` | `TemplateCache` + `new`/`cache_key`/`decide` | cache collaborator |
+| `src/template_source.rs` | `GitHubRepository::with_ref`/`with_auth`/`resolve_classified` | additive builders + classified resolve |
+
+## Wave: DISTILL / [REF] Test placement
+
+- **Documentation SSOT**: `tests/acceptance/template-source/*.feature` (4 files) —
+  precedent: `tests/acceptance/cv-variant-build/`.
+- **Driving-adapter / subprocess scenarios**: `tests/template_source_scenarios.rs`
+  (external integration crate) — precedent: `tests/tui_job_applications_scenarios.rs`
+  - `tests/cli_smoke.rs` (`env!("CARGO_BIN_EXE_rusty_cv_creator")` + `tempfile`).
+- **Unit-level specifications**: **in-crate** `#[cfg(test)] mod distill_specs` in
+  `src/template_source.rs` and `mod uc1_specs` in `src/command_runner.rs`. They
+  live in-crate (NOT in a `tests/template_source_specifications.rs` file) because
+  `TemplateSource`, the scaffolds, and `command_runner::testing::FakeRunner` are
+  **binary-private** — they are not on the `lib.rs` facade (only
+  `database`/`models`/`schema`/`tui` are), and `helpers` (a transitive dependency)
+  references the `main.rs`-local `is_tailscale_connected`, so exposing them via the
+  library would cascade. This matches the existing green precedent: the skeleton's
+  own FakeRunner specs already live in `src/template_source.rs::tests`. Recorded in
+  `distill/upstream-issues.md`.
+
+## Wave: DISTILL / [REF] Driving Adapter coverage
+
+The sole driving adapter is the `insert` CLI subcommand (clap, D6 — sourcing is
+transparent). Scenario 3 (`ts01_ac3_bad_template_value_fails_fast_naming_the_value`)
+spawns the **built binary** and asserts a non-zero exit naming the offending
+value — a real subprocess driving-adapter test, not an orchestration-layer call.
+The git happy path is driven at the `create_directory` seam by the in-crate
+walking skeleton (binary-private symbols unreachable from an external crate).
+
+## Wave: DISTILL / [REF] Traceability (AC → scenario → test)
+
+| AC | Scenario | Test (file::name) | State |
+| --- | --- | --- | --- |
+| TS-01/AC1 | 1 | `src/file_handlers.rs::walking_skeleton_github_source_resolves_template_dir` | GREEN (skeleton) |
+| TS-01/AC2 | 2 | `src/template_source.rs::tests::test_detect_existing_dir_is_local` (+ `…test_local_directory_resolves_to_passthrough_path`) | GREEN |
+| TS-01/AC3 | 3 | `tests/template_source_scenarios.rs::ts01_ac3_bad_template_value_fails_fast_naming_the_value` (+ unit `…test_detect_unrecognised_value_errors_naming_value`) | GREEN |
+| TS-01/D1 | 4, 5 | `src/template_source.rs::distill_specs::ts01_is_git_url_classifies_known_forms` | GREEN (proptest) |
+| TS-02/AC1 | 6 | `…distill_specs::ts02_ac1_ssh_source_clones_via_git_at_url` | PENDING (RED) |
+| TS-02/AC2 | 7 | `…distill_specs::ts02_ac2_token_uses_askpass_and_never_on_argv` | PENDING (RED) |
+| TS-02/AC3 | 8 | `…distill_specs::ts02_ac3_auth_failure_stderr_classified_as_auth` (+ `command_runner.rs::uc1_specs::uc1_run_capturing_exposes_stderr` for UC-1) | PENDING (RED) |
+| TS-03/AC1 | 9 | `…distill_specs::ts03_ac1_pinned_ref_is_checked_out` | PENDING (RED) |
+| TS-03/AC2 | 10 | skeleton default-branch resolve (`…walking_skeleton…`) | GREEN (reference) |
+| TS-03/AC3 | 11 | `…distill_specs::ts03_ac3_bad_ref_classified_no_silent_fallback` | PENDING (RED) |
+| TS-04/AC1 | 12 | `…distill_specs::ts04_cache_action_matrix` (`ReuseStale`) | PENDING (RED) |
+| TS-04/AC2 | 13 | `…distill_specs::ts04_cache_action_matrix` (`Abort`) | PENDING (RED) |
+| TS-04/AC3 | 14, 15 | `…distill_specs::ts04_cache_action_matrix` (`Clone`/`FetchCheckout`) | PENDING (RED) |
+| TS-04 (key) | 16 | `…distill_specs::ts04_cache_key_is_deterministic` | PENDING (RED) |
+
+## Wave: DISTILL / [REF] Self-Completeness Audit (Phase 2.5)
+
+`nw-at-completeness-check` over the 16 scenarios. Verdict:
+**ACCEPTABLE_WITH_DOCUMENTED_GAPS** — happy/error/edge/property coverage for every
+AC; all four driven behaviours (detect, auth, ref, cache) have explicit error
+paths (56% error/edge). All gaps are `AT_GAP_IN_DELIVERY_SCOPE` (filled by the
+pending specs in DELIVER); **zero `SPECIFICATION_AMBIGUITY`** blockers — DISCUSS
+ACs and DESIGN ports/decisions fully determine every scenario.
+
+## Wave: DISTILL / [REF] Mandate-12 (SSOT) note — informational
+
+Rust + no cucumber-rust harness ⇒ no `pytest-bdd`-style step decorators; the
+DSL/step-reuse-ratio metric does not apply. Domain concepts ARE expressed once via
+the type system (criterion 1): `AuthMode`, `CacheAction`, `TemplateSourceError`,
+`TemplateCache` are typed enums/structs the specs reuse. Step-reuse-ratio is N/A
+for this harness shape (config/decision-shaped feature). Criteria 1–3 are met in
+spirit; criterion 4 (ratio) is not measured (no decorator surface).
+
+## Wave: DISTILL / [REF] Pre-requisites
+
+- DESIGN driving port (CLI `insert`) + driven ports (`TemplateSource`,
+  `CommandRunner` incl. UC-1, filesystem cache, environment) per the DESIGN [REF]
+  sections + ADR-0008.
+- `git`/`just`/`tectonic` on PATH (ADR-0004 pre-usage checks) for the subprocess
+  scenario — satisfied under `devenv shell`.
+- No DEVOPS environment matrix exists; sensible defaults applied (single-user local
+  CLI; `tempfile::TempDir`; `file://` bare repo for deterministic git real-IO). Not
+  a blocker.
+- Outcomes registry: **N/A — deferred** (no `docs/product/outcomes/registry.yaml`
+  in this project; not bootstrapped per orchestrator instruction).

--- a/docs/feature/template-source/slices/slice-01-public-clone-skeleton.md
+++ b/docs/feature/template-source/slices/slice-01-public-clone-skeleton.md
@@ -1,0 +1,47 @@
+# Slice 01 — Public clone skeleton (TS-01)
+
+**Goal:** A git URL in `cv_template_path` is auto-detected and the public repo's default branch is cloned, then handed
+to the existing build flow.
+
+**Story:** TS-01 · **Walking skeleton:** yes
+
+## IN scope
+
+- Auto-detect LOCAL (existing dir) vs GITHUB (`git@…` / `https://….git`) from `cv_template_path`.
+- `TemplateSource` trait + `LocalDirectory` (passthrough) + `GitHubRepository` (public clone) impls.
+- Clone default branch into the cache dir; return that local dir to `prepare_path_for_new_cv` before `copy_dir`.
+- Backward-compat: existing local-dir config path unchanged.
+- `git` pre-usage PATH check (ADR-0004) for GITHUB.
+
+## OUT scope
+
+- Private auth (slice 02), ref pinning (slice 03), cache-reuse-on-failure / offline (slice 04).
+- CLI overrides; non-GitHub hosts; git-mechanism optimisation.
+
+## Learning hypothesis
+
+Disproves **"a `TemplateSource` resolver can turn a git URL into a local dir the existing `copy_dir` flow accepts"** if
+the cloned dir cannot drive an unmodified `just build`.
+Confirms the end-to-end seam works → slices 02–04 only thicken it.
+
+## Acceptance criteria
+
+TS-01 AC1–AC4 (see feature-delta.md). Production data: clone the real public repo form.
+
+## Dependencies
+
+None (first slice). Establishes the abstraction the others extend.
+
+## Effort / reference class
+
+≤1 day. Reference: prior port-introduction slices in this repo (`CommandRunner`, ADR-0002) — trait + one concrete impl +
+wiring.
+
+## Pre-slice SPIKE
+
+**Recommended:** `/nw-spike template-source` to pick the git mechanism (shell-out `git` vs `git2`/`gitoxide`) before
+implementing this slice — network I/O is new to the codebase.
+
+## Dogfood moment
+
+Same day: point `cv_template_path` at the public repo URL and generate one real CV.

--- a/docs/feature/template-source/slices/slice-02-private-auth.md
+++ b/docs/feature/template-source/slices/slice-02-private-auth.md
@@ -1,0 +1,38 @@
+# Slice 02 — Private repo auth (TS-02)
+
+**Goal:** Pull a private GitHub repo using the machine's existing SSH key, or a token from env for HTTPS.
+
+**Story:** TS-02
+
+## IN scope
+
+- SSH clone (`git@…`) using existing agent/key — the real workflow for `git@github.com:chess-seventh/cv.git`.
+- Optional `cv_template_auth = auto | ssh | token`; `token` reads `GITHUB_TOKEN` from env for `https://` private URLs.
+- Auth-specific fast-fail hint distinct from network errors.
+
+## OUT scope
+
+- Ref pinning (slice 03), caching/offline (slice 04).
+- Storing any secret in INI (forbidden — env only).
+
+## Learning hypothesis
+
+Disproves **"the machine's existing git auth is sufficient; no bespoke token plumbing is needed"** if the real private
+repo cannot be cloned with the existing SSH key.
+Confirms auth is a thin add over slice 01.
+
+## Acceptance criteria
+
+TS-02 AC1–AC4. Production data: clone the real private `git@github.com:chess-seventh/cv.git`.
+
+## Dependencies
+
+Slice 01 (`GitHubRepository` impl + resolver).
+
+## Effort / reference class
+
+≤1 day. Mostly auth-mode branching + error mapping on the slice-01 clone path.
+
+## Dogfood moment
+
+Same day: generate a CV sourced from the real private repo.

--- a/docs/feature/template-source/slices/slice-03-ref-pinning.md
+++ b/docs/feature/template-source/slices/slice-03-ref-pinning.md
@@ -1,0 +1,38 @@
+# Slice 03 — Ref pinning (TS-03)
+
+**Goal:** Optional `cv_template_ref` selects an exact branch / tag / commit SHA; the resolved SHA is logged.
+
+**Story:** TS-03
+
+## IN scope
+
+- `[cv] cv_template_ref` optional config; checkout of branch, tag, or full/short SHA.
+- Log the resolved commit SHA for reproducibility.
+- Unset → default branch HEAD (slice 01 behaviour preserved).
+- Unresolvable ref → fast-fail naming the bad ref; **no** silent fallback to default branch.
+
+## OUT scope
+
+- Caching/offline (slice 04); CLI `--template-ref` override.
+
+## Learning hypothesis
+
+Disproves **"an exact template version can be reproducibly checked out and proven via its resolved SHA"** if SHA/tag
+checkout does not yield a deterministic build input.
+Confirms reproducibility — feeds the "0 stale-template incidents" KPI.
+
+## Acceptance criteria
+
+TS-03 AC1–AC4. Production data: build from two different real refs, observe different resolved SHAs.
+
+## Dependencies
+
+Slice 01 (clone path). Independent of slice 02 (works for public or private).
+
+## Effort / reference class
+
+≤1 day. Checkout-after-clone + ref resolution + error path.
+
+## Dogfood moment
+
+Same day: pin to a tag and generate a CV; confirm the logged SHA.

--- a/docs/feature/template-source/slices/slice-04-cache-offline.md
+++ b/docs/feature/template-source/slices/slice-04-cache-offline.md
@@ -1,0 +1,40 @@
+# Slice 04 — Cache + offline reuse (TS-04)
+
+**Goal:** Cache clones per `repo@ref`; on fetch failure reuse the cache so CV generation works offline. No cache → hard
+fast-fail.
+
+**Story:** TS-04
+
+## IN scope
+
+- Cache keyed by `repo@ref` under `cv_template_cache` (default `~/.cache/rusty-cv-creator/templates`).
+- Successful fetch creates/updates the cache.
+- Fetch failure (offline/auth/url) WITH usable cache → reuse it, warn (name cache + fetch date).
+- Fetch failure WITHOUT cache → abort fast, actionable hint, no partial/blank CV.
+
+## OUT scope
+
+- Cache eviction / GC policy (note for DESIGN; unbounded for now).
+- Concurrent-run cache locking (single-user tool).
+
+## Learning hypothesis
+
+Disproves **"after one successful fetch, CV generation works with no network"** if cache reuse cannot produce a
+build-ready template offline.
+Confirms the offline-success KPI (target 100%).
+
+## Acceptance criteria
+
+TS-04 AC1–AC4. Production data: fetch the real repo once, drop network, re-run.
+
+## Dependencies
+
+Slice 01 (clone + cache dir). Composes with slices 02/03 (cache key includes ref).
+
+## Effort / reference class
+
+≤1 day. Cache-key + presence check + failure→reuse branch + tests for both failure paths.
+
+## Dogfood moment
+
+Same day: generate a CV, disable network, generate again from cache.

--- a/docs/feature/template-source/spike/findings.md
+++ b/docs/feature/template-source/spike/findings.md
@@ -1,0 +1,73 @@
+# SPIKE Findings — template-source
+
+**Date:** 2026-06-22 · **Agent:** Attila (nw-software-crafter) · **Phase:** PROBE
+
+## Assumption tested (the ONE)
+
+> Shelling out to system `git` can clone the **private** repo
+> `git@github.com:chess-seventh/cv.git` over SSH (existing agent), checkout an
+> arbitrary ref/SHA, into a cache dir, and reuse the cache offline — with **no
+> Rust git library**.
+
+Probe: `/tmp/spike_template-source/probe.sh` (throwaway, shell). Mechanism
+validation only; no perf budget. Run against the **real private repo**, not a
+fixture.
+
+## Verdict: ✅ WORKS
+
+Shell-out to `git` is sufficient for every DISCUSS-locked requirement. No
+`git2`/`gitoxide` dependency is needed.
+
+| # | Check | Result | Maps to |
+| --- | ------- | -------- | --------- |
+| 1 | SSH clone of private repo, default branch | ✅ **3.5s**, branch `main`, head `eff41fc`. Existing SSH agent used — zero credential plumbing. | TS-02 |
+| 2 | Build contract present in clone | ✅ `Justfile` + `PivaFrancesco-{senior-devops,senior-platform-engineer,engineering-manager}.tex` + `awesome-cv.cls`. Exactly what `compile_cv` / `just build <variant>` consumes. | TS-01, D5 |
+| 3 | Checkout arbitrary short SHA | ✅ detached HEAD (expected) | TS-03/AC1 |
+| 4 | Bad ref | ✅ **non-zero exit, no silent fallback** | TS-03/AC3 |
+| 5 | Cache reuse via `fetch` | ✅ **1.7s** vs 3.5s full clone | TS-04/AC3 |
+| 6 | Shallow `--depth 1` | ✅ works but **same 41M** — repo size is fonts/images, not history. Shallow is NOT the perf lever. | (rejected optimisation) |
+| 7 | Offline `fetch` (host unreachable) | ✅ git fails, **cache dir remains usable** | TS-04/AC1 |
+
+## Timing (informal, single run)
+
+- Cold full clone (SSH, private): **~3.5s**
+- Warm cache `fetch`: **~1.7s**
+- Repo working tree: **41 MB** (binary assets dominate; shallow clone saves ~nothing)
+
+## Edge cases / caveats discovered
+
+- **HTTPS anon** path (TS-01 public) not exercised against this repo (it is
+  private). HTTPS reachability to GitHub was confirmed separately
+  (`git ls-remote https://github.com/...` → exit 0); the public-clone mechanism
+  is the same `git clone <url>` shell-out, lower-risk than the SSH case that
+  already passed.
+- Probe step 7 printed a spurious `exit=0` due to a `$?`-after-pipe scripting
+  slip; git's own output (`fatal: Could not read from remote repository`) and the
+  surviving cache confirm the real behaviour. Mechanism conclusion unaffected.
+- SHA checkout leaves a **detached HEAD** — fine for a build-only consumer, but
+  the resolver must `git -C <cache> checkout <ref>` explicitly and log the
+  resolved SHA (TS-03/AC1) rather than relying on branch state.
+
+## Design implications (for DESIGN)
+
+1. **Mechanism = shell-out to `git`**, routed through the existing
+   **`CommandRunner` port (ADR-0002)** — keeps it testable with `FakeRunner`,
+   no new external crate, consistent with the codebase's hexagonal style.
+2. **`git` gated by the existing pre-usage PATH check** (`ensure_tools_available`,
+   ADR-0004) when source is GITHUB — same pattern as `just`/`tectonic`.
+3. **Cache key = sanitised `repo@ref`** under `cv_template_cache`
+   (default `~/.cache/rusty-cv-creator/templates`). Reuse = `fetch` + `checkout`,
+   not re-clone. This is the real perf lever (1.7s vs 3.5s); **drop shallow-clone**.
+4. **Auth is inferred from URL scheme** (`git@…` → SSH/agent; `https://…` → anon,
+   or token via `GIT_ASKPASS`/env for private HTTPS). No secret touches the INI.
+5. **Resolver returns a local dir** that flows unchanged into
+   `prepare_path_for_new_cv` → `copy_dir` (D5 holds: downstream untouched).
+6. **`TemplateSource` trait** with `LocalDirectory` (passthrough) +
+   `GitHubRepository` (CommandRunner-backed) implementors — the OO shape from
+   DISCUSS D7 is confirmed viable.
+
+## Constraints discovered
+
+- Detached-HEAD after SHA checkout → always log resolved SHA explicitly.
+- 41 MB clone → first-run latency ~3.5s is unavoidable; cache makes subsequent
+  runs ~1.7s. Acceptable for a single-user CLI; note for the clone-latency KPI.

--- a/docs/feature/template-source/spike/upstream-issues.md
+++ b/docs/feature/template-source/spike/upstream-issues.md
@@ -1,0 +1,51 @@
+# Upstream Issues — template-source
+
+> Contradictions encountered during SPIKE Phase 3 (walking-skeleton promotion)
+> that could not be resolved without violating a locked decision, the DISCUSS
+> spec, or a project quality gate. Recorded here instead of being force-fitted
+> (walking-skeleton DoD item 7).
+
+## UI-1 — Mandated commit title exceeds the repo's gitlint 72-char limit
+
+**Date:** 2026-06-22 · **Wave:** SPIKE Phase 3 (skeleton) · **Severity:** LOW (process)
+
+**Contradiction.** The skeleton task mandated this exact commit title:
+
+```text
+feat(template-source): walking skeleton — clone git URL template via CommandRunner
+```
+
+That title is **82 characters**. The repository's `commit-msg` hook runs
+`gitlint` (`.pre-commit-config.yaml`, hook id `gitlint`), whose default **T1
+rule caps the title at 72 characters**. The two requirements are mutually
+exclusive: the mandated message can never pass the commit-msg gate.
+
+**Evidence.**
+
+```text
+✨ GitLint...............................................................Failed
+  1: T1 Title exceeds max length (82>72):
+     "feat(template-source): walking skeleton — clone git URL template via CommandRunner"
+```
+
+All substantive gates passed in the same run (Clippy ✓, TreeFMT ✓, EOF ✓,
+secrets ✓), and the DoD-named gates were verified independently:
+`rustfmt --edition 2024` (clean), `cargo clippy --all-targets -- -D warnings`
+(clean), `cargo test` (131 passed / 0 failed).
+
+**Resolution applied (no gate bypassed).** The commit was landed with a
+conventional-commit subject shortened to ≤72 chars, and the **exact mandated
+sentence preserved verbatim as the first line of the commit body**, so the
+intended message is recoverable from `git log` without `--no-verify`.
+
+Committed title used:
+
+```text
+feat(template-source): walking skeleton clones git URL via CommandRunner
+```
+
+**Decision needed upstream (DESIGN / operator).** Pick one:
+
+1. Accept the shortened title convention for this feature (gitlint stays 72), or
+2. Relax/configure gitlint's T1 limit (platform-architect territory) if longer
+   titles with em-dash phrasing are desired going forward.

--- a/docs/feature/template-source/spike/wave-decisions.md
+++ b/docs/feature/template-source/spike/wave-decisions.md
@@ -1,0 +1,65 @@
+# SPIKE Decisions — template-source
+
+## Assumption Tested
+
+- Shelling out to system `git` can clone the **private** `git@github.com:chess-seventh/cv.git` over SSH (existing
+  agent), checkout an arbitrary ref/SHA into a cache dir, and reuse the cache offline — with no Rust git library.
+
+## Probe Verdict
+
+- **WORKS**: clone 3.5s, ref/SHA checkout OK, bad-ref fails non-zero (no silent fallback), cache `fetch` reuse 1.7s,
+  offline leaves cache usable, build contract (`Justfile` + variant `.tex`) present. See `findings.md`.
+
+## Promotion Decision
+
+- **PROMOTE** (user, 2026-06-22): mechanism proven and worth building on; refactor the probe into a committed walking
+  skeleton for slice 01 / TS-01.
+
+## Walking Skeleton (PROMOTE)
+
+- Driving adapter: `rusty_cv_creator insert` (existing CLI entry) — sourcing transparent inside
+  `prepare_path_for_new_cv`.
+- Mechanism: `git` shell-out via the existing `CommandRunner` port (ADR-0002); `git` gated by `ensure_tools_available`
+  (ADR-0004).
+- Acceptance test: real git clone from a **local bare-repo fixture (`file://`)** — exercises the real git driven adapter
+  without network flakiness; asserts the resolved template dir is produced from a git-URL source.
+- Commit: `af03e33` on `feature/template-source-skeleton` (3 files, +392/−11; 131 tests green, +9; clippy/fmt clean; not
+  pushed).
+- Files: `src/template_source.rs` (new: `TemplateSource` trait + `LocalDirectory` + `GitHubRepository` +
+  `detect_template_source`/`is_git_url`), `src/file_handlers.rs` (threaded `&dyn CommandRunner`, resolve before
+  `copy_dir`, `resolve_template_cache_dir`), `src/main.rs` (wiring).
+- Acceptance test: `walking_skeleton_github_source_resolves_template_dir` (`src/file_handlers.rs:523`, tagged
+  `// @walking_skeleton @driving_port`) — real `git clone` via `SystemRunner` from a `file://` bare-repo fixture → real
+  `copy_dir`; asserts the git-sourced template lands ready to build (LaTeX build intentionally not run).
+- Demo command: `devenv shell -- cargo test --bin rusty_cv_creator walking_skeleton_github_source_resolves_template_dir`
+
+## Upstream Issues
+
+- **UI-1** (LOW, process): mandated 82-char commit title violated repo gitlint T1 (≤72). Resolved without bypassing the
+  hook (shortened subject, full sentence in body). See `upstream-issues.md`. Operator decision pending: accept short
+  titles (recommended) vs. relax gitlint.
+
+## Skeleton-revealed notes (for DESIGN)
+
+- `file://` is now also recognised as a git URL (superset of D1's `git@…`/`https://….git`) — enables deterministic
+  offline tests; breaks nothing.
+- ADR-0004 PATH check uses global `PATH` → git-touching tests must be `#[serial]`. DESIGN may make the tool-check
+  injectable to drop the global-state coupling.
+- `GitHubRepository` always clones fresh (no reuse yet) — cache-key-by-`repo@ref` + reuse/offline are slices 03/04
+  (TS-03/TS-04).
+
+## Design Implications (for DESIGN)
+
+- `TemplateSource` trait + `LocalDirectory` (passthrough) + `GitHubRepository` (CommandRunner-backed) — OO shape
+  (DISCUSS D7) confirmed viable.
+- Cache key = sanitised `repo@ref` under `cv_template_cache` (default `~/.cache/rusty-cv-creator/templates`); reuse via
+  `fetch`+`checkout`, NOT re-clone. **Drop shallow-clone** (binary assets dominate; no benefit).
+- Auth inferred from URL scheme (`git@…` SSH / `https://…` anon|token-from-env); no secret in INI.
+- SHA checkout → detached HEAD → always log resolved SHA (TS-03/AC1).
+- Downstream build flow untouched (D5): resolver returns a local dir into `copy_dir`.
+
+## Constraints Discovered
+
+- First-run clone latency ~3.5s (41 MB, binary assets) unavoidable; cache makes reruns ~1.7s — feeds the clone-latency
+  KPI.
+- Detached HEAD after SHA checkout — resolver must checkout explicitly and log the resolved SHA.

--- a/docs/product/architecture/adr-0008-template-source.md
+++ b/docs/product/architecture/adr-0008-template-source.md
@@ -1,0 +1,91 @@
+# ADR-0008: Template sourcing via git shell-out through CommandRunner
+
+## Status
+
+Accepted (DESIGN wave, feature `template-source`; supersedes the deferred
+git-mechanism question recorded in feature-delta D7 / DoD item 9)
+
+## Context
+
+`rusty_cv_creator` currently requires the CV template to already exist as a local
+directory pointed at by `[cv] cv_template_path`. The `template-source` feature
+(stories TS-01..TS-04) lets that value also be a GitHub git URL, so the tool
+clones the canonical template itself, can pin an exact ref, and keeps working
+offline from a cache. The DISCUSS wave locked the OO shape (D7): a
+`TemplateSource` trait with `LocalDirectory` and `GitHubRepository` implementors.
+The remaining decision — **how** the git work is performed — was explicitly
+deferred to a SPIKE/DESIGN decision.
+
+A throwaway SPIKE (`docs/feature/template-source/spike/findings.md`, verdict
+**WORKS**) proved that shelling out to the system `git` binary satisfies every
+locked requirement against the real private repo: SSH clone using the existing
+agent (3.5s), arbitrary ref/SHA checkout (detached HEAD), bad-ref fails non-zero
+with no silent fallback, warm-cache `fetch` reuse (1.7s), and offline `fetch`
+leaving the cache usable. Shallow clone saved nothing (the 41 MB is binary
+assets, not history), so it is dropped.
+
+Testability is this codebase's primary quality driver (ADR-0002, ADR-0005). Any
+mechanism must be unit-testable without real network or credentials.
+
+## Decision
+
+Source the template by **shelling out to the system `git` binary, routed through
+the existing `CommandRunner` driven port (ADR-0002)**. No Rust git library is
+added. `git` is gated by the existing pre-usage PATH check
+(`ensure_tools_available`, ADR-0004) when the source is a git URL, exactly as
+`just`/`tectonic` already are.
+
+Mechanics:
+
+- **Cache** under `[cv] cv_template_cache` (default
+  `~/.cache/rusty-cv-creator/templates`), keyed by a sanitised `repo@ref`. Reuse
+  is `git fetch` + `git checkout` of an existing cache entry, **not** a re-clone;
+  a fresh `repo@ref` is a full clone. Shallow clone is not used.
+- **Ref pinning** (`[cv] cv_template_ref`): checkout the branch/tag/SHA and log
+  the resolved SHA; an unresolvable ref aborts (no silent fallback to default).
+- **Auth** inferred from URL scheme (`git@…` → SSH agent; `https://…` → anon),
+  overridable by `[cv] cv_template_auth = auto | ssh | token`. The `token` mode
+  reads `GITHUB_TOKEN` from the environment and feeds it to git via an askpass
+  helper (`git -c core.askpass=…`); the token is never read from or written to
+  the INI, never placed on the git argv, and never persisted into the cache
+  repo's `.git/config` remote URL.
+- **Offline fallback** (TS-04): a fetch failure with a usable cache entry reuses
+  it (with a warning); no cache entry aborts fast with an actionable hint.
+
+## Alternatives considered
+
+- **`git2` (libgit2 bindings)** — rejected. Adds a C-library dependency and build
+  complexity (libgit2/OpenSSL), and its SSH-agent / credential-callback story is
+  more code than simply inheriting the user's working `git` auth, which the SPIKE
+  proved sufficient with zero credential plumbing. No requirement (single-user
+  CLI, `git` already a devenv tool) justifies the dependency. License is fine
+  (GPL-2.0-with-linking-exception) but the integration cost is not warranted.
+- **`gitoxide` (pure-Rust git)** — rejected. Promising and dependency-light at
+  the toolchain level, but in 2026 its higher-level clone/fetch/checkout +
+  credential-helper surface is still maturing; betting the only network path in
+  the codebase on it adds risk for no benefit over the system `git` the SPIKE
+  validated. Reconsider only if removing the `git` runtime dependency becomes a
+  goal.
+- **Keep `std::process::Command` calls inline** — rejected for the same reason as
+  ADR-0002: it would make the clone/fetch/checkout paths untestable without real
+  network and credentials. Routing through `CommandRunner` keeps them fake-able.
+- **Shallow clone (`--depth 1`)** — rejected as a performance lever: the SPIKE
+  showed the working tree is 41 MB of binary assets, so `--depth 1` saved
+  essentially nothing. Cache `fetch` reuse (1.7s vs 3.5s) is the real lever.
+
+## Consequences
+
+- Positive: zero new crates; consistent with the codebase's hexagonal style;
+  clone/fetch/checkout are unit-testable with `FakeRunner`; the user's existing
+  git auth (SSH agent) works with no plumbing; secrets stay out of the repo, the
+  INI, the argv, and the cache config.
+- Positive: the cache makes reruns ~2x faster and enables offline generation.
+- Negative: the `CommandRunner` port must be **extended** with a
+  stderr-capturing method so git's failure output can be classified into distinct
+  actionable hints (auth vs network/offline vs bad-ref); see the template-source
+  design in the feature delta. This is an additive, backward-compatible change to
+  a shared port (ADR-0002).
+- Negative: a hard runtime dependency on the `git` binary for git sources
+  (mitigated by the ADR-0004 pre-usage check with a devenv hint).
+- Negative: cache grows unbounded (no GC/eviction) — accepted for now, noted as a
+  future concern (out-of-scope per DISCUSS).

--- a/docs/product/architecture/brief.md
+++ b/docs/product/architecture/brief.md
@@ -205,6 +205,24 @@ core; effects (subprocess, fs, db) live in the shell and behind ports.
 `list`/`update`/DB-filtering and `parse_date` wiring remain partial (carried
 forward as gaps — see evolution record).
 
+> Marked **delivered** by the DELIVER wave (feature `template-source`, branch
+> `feature/template-source-skeleton`). See
+> `docs/feature/template-source/feature-delta.md` and
+> `docs/evolution/template-source-evolution.md`.
+
+| Component | Delivered by | Status |
+| --- | --- | --- |
+| `CommandRunner::run_capturing` (UC-1 stderr seam) + `CommandOutcome` | `c144d40` | delivered |
+| `TemplateSourceError` enum + `classify_git_stderr` | `037c778` | delivered |
+| `AuthMode` + `auth_invocation_flags` (SSH / token via `core.askpass`) | `361b466` | delivered |
+| Ref pinning (`with_ref` + checkout + resolved-SHA log) | `8887c2f` | delivered |
+| `TemplateCache` (`decide` / `CacheAction` matrix + deterministic `cache_key`) | `07f7831` | delivered |
+| `TemplateSource` / `LocalDirectory` / `GitHubRepository` wired into `prepare_path_for_new_cv` | `52457d1` | delivered |
+
+Mutation: 98.1% kill on `src/template_source.rs`. DoD item 6 (HTTPS-token askpass
+helper executable) is **partial/deferred** — SSH path fully works; see the
+`template-source` evolution record for the two follow-ups.
+
 ### External integrations (contract-test annotation for DEVOPS handoff)
 
 The highest-risk boundary is the **CV template repository**

--- a/docs/product/architecture/brief.md
+++ b/docs/product/architecture/brief.md
@@ -8,7 +8,7 @@
 ## Prior Wave Consultation
 
 | Artifact | Wave | Status | Note |
-|----------|------|--------|------|
+| --- | --- | --- | --- |
 | `docs/product/architecture/brief.md` (System Architecture) | DESIGN (Titan) | ⊘ absent | This file bootstraps the SSOT; no prior `## System Architecture` section. |
 | `docs/product/architecture/brief.md` (Domain Model) | DESIGN (Hera) | ⊘ absent | No prior `## Domain Model`. Domain captured inline below. |
 | DISCUSS requirements / user stories / AC | DISCUSS | ⊘ absent | LEAN retroactive backfill; requirements reverse-engineered from code + commits. |
@@ -26,6 +26,7 @@ document the realized architecture and decisions, they do not propose new work.
 CV PDFs from a LaTeX template repository and records them in a database.
 
 Capabilities:
+
 - Select one of **4 CV variants** (`senior-devops`, `senior-platform-engineer`,
   `senior-sre`, `engineering-manager`) per job application.
 - Build the selected variant via a config-driven `just build <variant>`
@@ -54,7 +55,7 @@ layered frameworks were unnecessary and are not used. See ADR-0002, ADR-0003.
 ### Component decomposition
 
 | Component | Path | Responsibility |
-|-----------|------|----------------|
+| --- | --- | --- |
 | Entrypoint / Orchestrator | `src/main.rs` | `main`, `prepare_cv` (build orchestration), `is_tailscale_connected`. |
 | CLI (driving adapter) | `src/cli_structure.rs` | clap `UserInput`/`UserAction`/`FilterArgs` (incl. `--variant`); `match_user_action` dispatch. |
 | Insert use case | `src/cv_insert.rs` | `insert_cv` — wires variant resolution → build → optional persist. |
@@ -64,6 +65,7 @@ layered frameworks were unnecessary and are not used. See ADR-0002, ADR-0003.
 | Persistence | `src/database.rs` | `DbConnection` (diesel `MultiConnection`), connection + CRUD functions. |
 | Domain model | `src/models.rs`, `src/schema.rs` | diesel `Cv`/`NewCv`, `cv` table. |
 | Config | `src/config_parse.rs`, `src/global_conf.rs` | INI load + immutable injected `AppContext` (ADR-0006), typed accessors. |
+| Template sourcing | `src/template_source.rs` | `TemplateSource` port + `LocalDirectory`/`GitHubRepository` adapters, `TemplateCache`, `detect_template_source` (ADR-0008). |
 | Helpers | `src/helpers.rs` | `ensure_tools_available`/`tool_on_path`, `view_cv_file`, `my_fzf`, path utils. |
 | Library facade | `src/lib.rs` | exposes `models` + `schema` + `tui`; enables `coverage_nightly` attribute. |
 | TUI | `src/tui/*.rs` | ratatui terminal UI (feature `tui-job-applications`) to browse/filter applications + open PDFs — `app`/`state`/`events`/`ui`/`db`/`terminal_guard`. |
@@ -71,15 +73,23 @@ layered frameworks were unnecessary and are not used. See ADR-0002, ADR-0003.
 ### Ports and adapters
 
 **Driving ports (inbound)**
+
 - **CLI** — clap parses `UserInput`; `match_user_action` dispatches to use cases.
 - **TUI** — a ratatui terminal UI (feature `tui-job-applications`) launched from the
   CLI; reads applications from the DB and opens PDFs. ADRs under
   `docs/feature/tui-job-applications/architecture/` (adr-001 ratatui, adr-002 module structure).
 
 **Driven ports (outbound)**
-- **`CommandRunner`** (subprocess effects) — `status`/`output`/`spawn`.
+
+- **`CommandRunner`** (subprocess effects) — `status`/`output`/`spawn` (plus a
+  stderr-capturing run added for template sourcing, see below).
   Adapters: `SystemRunner` (real `std::process::Command`), `FakeRunner` (tests).
-  Injected into `compile_cv`, `view_cv_file`, `is_tailscale_connected`. See ADR-0002.
+  Injected into `compile_cv`, `view_cv_file`, `is_tailscale_connected`, and the
+  `TemplateSource` resolver. See ADR-0002.
+- **`TemplateSource`** (template resolution) — resolves the configured
+  `cv_template_path` to a local template directory: `LocalDirectory` (passthrough,
+  backward compat) or `GitHubRepository` (git clone/fetch/checkout via
+  `CommandRunner`). See ADR-0008 and the `### Template sourcing` subsection below.
 - **`DbConnection`** (persistence) — diesel `MultiConnection` enum.
   Adapters: `PgConnection` (prod), `SqliteConnection` (tests / local). Functions
   take `&mut DbConnection`. See ADR-0003.
@@ -94,10 +104,40 @@ External tools (`just`, `tectonic`, `pdf_viewer`/zathura, `sudo`+`tailscale`)
 are gated by **pre-usage PATH checks** (`ensure_tools_available`) at the
 orchestration layer before any subprocess runs. See ADR-0004.
 
+### Template sourcing
+
+> Feature `template-source` (branch `feature/template-source-skeleton`). Lets
+> `[cv] cv_template_path` be a GitHub git URL as well as a local directory, with
+> optional ref pinning, auth, and an offline cache. See ADR-0008 and
+> `docs/feature/template-source/`.
+
+The `TemplateSource` driven port resolves the configured template value to a
+local directory that the existing `copy_dir` flow consumes unchanged (D5). A
+factory `detect_template_source` auto-detects (D1): an existing readable
+directory → `LocalDirectory` (passthrough, the backward-compat path); a git URL
+(`git@…`, `https://….git`, or `file://…`) → `GitHubRepository`.
+
+`GitHubRepository` shells out to the system `git` binary through the existing
+`CommandRunner` port (no Rust git crate; ADR-0008), gated by the ADR-0004
+pre-usage PATH check. It caches per `repo@ref` under `[cv] cv_template_cache`
+(default `~/.cache/rusty-cv-creator/templates`), reusing an entry via
+`fetch`+`checkout` rather than re-cloning. A `TemplateCache` collaborator owns the
+cache-key derivation and a **pure** reuse-vs-fetch-vs-abort decision
+(`CacheAction`); only the executor touches disk, and its write universe is bounded
+to the cache dir. Ref pinning (`[cv] cv_template_ref`) checks out the
+branch/tag/SHA and logs the resolved SHA, aborting (never silently falling back)
+on an unresolvable ref. Auth (`[cv] cv_template_auth = auto|ssh|token`) is
+inferred from the URL scheme by default; `token` reads `GITHUB_TOKEN` from the
+environment and feeds git via `core.askpass`, never via the INI, the argv, or the
+cache repo's `.git/config`. Failures are classified by a typed
+`TemplateSourceError` enum (auth vs network/offline vs bad-ref vs no-cache) so
+each emits a distinct actionable hint; classification reads git's stderr, for
+which the `CommandRunner` port gains an additive stderr-capturing run.
+
 ### Technology stack (pinned, from `Cargo.toml`)
 
 | Dependency | Version | Role | License |
-|------------|---------|------|---------|
+| --- | --- | --- | --- |
 | Rust | edition 2021, **nightly** channel | language/toolchain (nightly for `coverage_attribute`) | — |
 | clap | 4.6.1 (`derive`) | CLI parsing (driving adapter) | MIT/Apache-2.0 |
 | diesel | 2.3.9 (`sqlite`,`postgres`,`returning_clauses_for_sqlite_3_35`) | ORM / persistence port | MIT/Apache-2.0 |
@@ -138,7 +178,7 @@ core; effects (subprocess, fs, db) live in the shell and behind ports.
 ### Decisions table
 
 | ID | Decision | ADR |
-|----|----------|-----|
+| --- | --- | --- |
 | D-1 | Variant-based CV build via Justfile (replaces xelatex + placeholder). | [ADR-0001](adr-0001.md) |
 | D-2 | `CommandRunner` port for all subprocess side-effects. | [ADR-0002](adr-0002.md) |
 | D-3 | diesel `MultiConnection` for backend-agnostic persistence. | [ADR-0003](adr-0003.md) |
@@ -146,6 +186,7 @@ core; effects (subprocess, fs, db) live in the shell and behind ports.
 | D-5 | Coverage discipline via test seams + `coverage_nightly` gating. | [ADR-0005](adr-0005.md) |
 | D-6 | Inject immutable `AppContext` (`&AppContext`) instead of `GLOBAL_VAR` `OnceCell`. | [ADR-0006](adr-0006-inject-appcontext.md) |
 | D-7 | CI quality gates made blocking (clippy `-D warnings`, rustfmt, threaded `cargo test`) + single release mechanism (`release.yml`; dormant `.releaserc*` removed). | [ADR-0007](adr-0007-ci-quality-gates-single-release.md) |
+| D-8 | Template sourcing via system `git` shell-out through `CommandRunner` (cache by `repo@ref`, ref pinning, env-only token). | [ADR-0008](adr-0008-template-source.md) |
 
 ### Component Inventory — delivery status
 
@@ -154,7 +195,7 @@ core; effects (subprocess, fs, db) live in the shell and behind ports.
 > `docs/evolution/cv-variant-build-evolution.md`.
 
 | Component | Delivered by | Status |
-|-----------|--------------|--------|
+| --- | --- | --- |
 | `DbConnection` (diesel `MultiConnection`) | `6472189` | delivered |
 | `CommandRunner` port + `SystemRunner`/`FakeRunner` | `23fde25` | delivered |
 | Variant build flow (resolve → `compile_cv` → per-year filing + cleanup) | `beb5034` | delivered |
@@ -171,6 +212,7 @@ The highest-risk boundary is the **CV template repository**
 (`just build <variant>` producing `<prefix>-<variant>.pdf`) is consumed by
 `compile_cv`. This is a build-time integration, not a web API, so consumer-driven
 HTTP contract tooling (Pact) does not apply. Recommended instead:
+
 - A **template-contract smoke test** in CI that runs `just build <variant>` for
   each of the 4 variants and asserts the expected PDF basename appears (verifies
   the recipe-name and output-naming contract that `compile_cv` assumes).

--- a/docs/product/architecture/c4-diagrams.md
+++ b/docs/product/architecture/c4-diagrams.md
@@ -27,7 +27,7 @@ C4Container
   Person(user, "Job Seeker")
   System_Boundary(cvc, "rusty_cv_creator (single binary)") {
     Container(cli, "CLI / Orchestrator", "Rust, clap", "Parses input, dispatches actions, orchestrates prepare_cv")
-    Container(build, "Build Subsystem", "Rust (file_handlers)", "Resolves variant, copies template, runs builder, copies out PDF")
+    Container(build, "Build Subsystem", "Rust (file_handlers)", "Resolves variant, copies template, builds, files PDF")
     Container(runner, "CommandRunner Port", "Rust trait", "SystemRunner (prod) / FakeRunner (test) for subprocesses")
     Container(persist, "Persistence", "Rust, diesel MultiConnection", "DbConnection over Postgres/SQLite; Cv CRUD")
     Container(config, "Config", "Rust, configparser + OnceCell", "INI-driven settings in GLOBAL_VAR")
@@ -102,3 +102,70 @@ C4Component
   Rel(remove, db, "Resolves (engine,url) then opens via")
 ```
 
+## Template sourcing — feature `template-source` (ADR-0008)
+
+### L1 — System Context (delta)
+
+```mermaid
+C4Context
+  title System Context — template sourcing
+  Person(user, "Job Seeker", "Sets cv_template_path to a local dir or a git URL")
+  System(cvc, "rusty_cv_creator", "Resolves the template before building")
+  System_Ext(github, "GitHub template repo", "git over SSH/HTTPS at a chosen ref")
+  System_Ext(cache, "Template cache", "~/.cache/rusty-cv-creator/templates (repo@ref)")
+  Rel(user, cvc, "Runs insert with a git-URL or local cv_template_path")
+  Rel(cvc, github, "Clones / fetches / checks out ref via system git")
+  Rel(cvc, cache, "Caches per repo@ref; reuses offline on fetch failure")
+```
+
+### L2 — Container (delta)
+
+```mermaid
+C4Container
+  title Container Diagram — template sourcing
+  Person(user, "Job Seeker")
+  System_Boundary(cvc, "rusty_cv_creator (single binary)") {
+    Container(build, "Build Subsystem", "Rust (file_handlers)", "prepare_path_for_new_cv resolves the template before copy_dir")
+    Container(tsrc, "Template Sourcing", "Rust (template_source)", "TemplateSource port + adapters + cache")
+    Container(runner, "CommandRunner Port", "Rust trait", "SystemRunner runs git; stderr captured for hints")
+    Container(config, "Config", "Rust, AppContext", "cv_template_path/_ref/_auth/_cache (INI)")
+  }
+  System_Ext(git, "system git", "clone/fetch/checkout, gated by ADR-0004 PATH check")
+  System_Ext(github, "GitHub template repo", "SSH/HTTPS remote")
+  ContainerDb(cache, "Template cache", "filesystem", "repo@ref working trees")
+  Rel(user, build, "Invokes insert")
+  Rel(build, tsrc, "Resolves template via")
+  Rel(build, config, "Reads sourcing keys from")
+  Rel(tsrc, runner, "Runs git through")
+  Rel(runner, git, "Executes")
+  Rel(git, github, "Talks to")
+  Rel(tsrc, cache, "Reads & writes (bounded to cache dir)")
+```
+
+### L3 — Component: TemplateSource subsystem
+
+```mermaid
+C4Component
+  title Component Diagram — TemplateSource subsystem
+  Container_Boundary(tsrc, "Template Sourcing") {
+    Component(detect, "detect_template_source / is_git_url", "template_source.rs", "Auto-detect LOCAL vs GITHUB (D1)")
+    Component(port, "TemplateSource", "trait (port)", "resolve(runner) -> local dir | TemplateSourceError")
+    Component(local, "LocalDirectory", "adapter", "Passthrough of an existing dir (pure, no write)")
+    Component(gh, "GitHubRepository", "adapter", "Clone/fetch/checkout at ref; write bounded to cache dir")
+    Component(cache, "TemplateCache", "collaborator", "Cache key + pure CacheAction decision + executor")
+    Component(auth, "AuthMode / auth plan", "value", "auto|ssh|token -> git invocation plan (pure)")
+    Component(err, "TemplateSourceError", "enum", "auth | network/offline | bad-ref | no-cache -> hint")
+  }
+  Component_Ext(runner, "CommandRunner", "port", "runs git, captures stderr for classification")
+  Component_Ext(tools, "ensure_tools_available", "helpers.rs", "ADR-0004 git PATH gate (probe)")
+  Component_Ext(env, "GITHUB_TOKEN", "environment", "Read only at execution; never in INI/argv/.git/config")
+  Rel(detect, port, "Constructs a")
+  Rel(local, port, "Implements")
+  Rel(gh, port, "Implements")
+  Rel(gh, tools, "Pre-checks git via")
+  Rel(gh, cache, "Asks for CacheAction from")
+  Rel(gh, auth, "Builds git args from")
+  Rel(gh, runner, "Runs git through")
+  Rel(auth, env, "Token mode reads")
+  Rel(gh, err, "Classifies git stderr into")
+```

--- a/docs/product/jobs.yaml
+++ b/docs/product/jobs.yaml
@@ -99,3 +99,38 @@ jobs:
       satisfaction: 2
       score: 12
       tier: MEDIUM
+  # --- feature: template-source (DISCUSS 2026-06-22) ---
+  - id: source-cv-template
+    persona: job-seeker
+    feature: template-source
+    one_liner: >-
+      When my CV template lives in a GitHub repo (or I set the tool up on a new machine), I want the tool to pull the template directly from a local directory OR a GitHub repo at a chosen version, so I can generate CVs anywhere without manually cloning and babysitting a local template copy.
+    job_story:
+      when: I run the tool on a machine without my template checked out, or I want a specific version of the canonical template
+      i_want_to: have the tool fetch the template from its GitHub repo (or use a local dir) automatically, at a pinned version, and keep working offline
+      so_i_can: generate CVs anywhere without manual git clone / path wrangling, always from the canonical template, even with no network
+    dimensions:
+      functional: >-
+        Auto-detect the configured source (local path vs git URL); for GitHub, clone/checkout an optional pinned ref (branch/tag/SHA) using public-anon or private auth; cache the result; on fetch failure reuse the cache; hand a local directory to the existing copy+build flow.
+      emotional: >-
+        Confident the right template version is used; relieved at not maintaining a manual clone; trusting that offline still works after the first fetch.
+      social: >-
+        Always builds from the canonical, version-controlled template — never a silently stale local copy sent to a hiring manager.
+    forces:
+      push: >-
+        Today the template MUST be pre-cloned to a local path; a new machine or sharing the tool means manual `git clone` + config, and a stale local copy can silently produce an out-of-date CV.
+      pull: >-
+        One config value (a git URL) and the tool pulls the canonical template itself, at a pinned version, cached for offline reuse.
+      anxiety: >-
+        Network/auth failures blocking CV generation; private-repo authentication; pulling the wrong version; clone latency on every run.
+      habit: >-
+        Manually `git clone`-ing the cv repo and pointing `cv_template_path` at the local checkout.
+    opportunity_score:
+      method: ODI (Importance + max(Importance - Satisfaction, 0))
+      importance: 7 # quality-of-life + portability enabler on top of the already-served core job
+      satisfaction: 3 # pre-feature: manual clone, no version control, breaks on a fresh machine
+      score: 11
+      tier: MEDIUM-HIGH
+      note: >-
+        Enabler for apply-with-tailored-cv: removes the manual pre-clone precondition and the stale-template risk. Single-user qualitative estimate.
+    stories: [TS-01, TS-02, TS-03, TS-04]

--- a/docs/product/journeys/source-cv-template.yaml
+++ b/docs/product/journeys/source-cv-template.yaml
@@ -1,0 +1,54 @@
+# Journey SSOT — source the CV template (local dir OR GitHub) before build
+# Feeds the existing `generate-cv` journey at its step 1 (before the working copy
+# is created). Authored in DISCUSS for feature `template-source`.
+schema_version: 1
+journey:
+  name: Source the CV template before building
+  goal: >-
+    Resolve the configured template source (local directory or GitHub repo), obtain a local copy at the chosen version, and hand it to the existing copy+build flow — without the user manually cloning the template.
+  persona: job-seeker
+  job: source-cv-template
+  feeds_journey: generate-cv # this journey precedes generate-cv step 1
+  emotional_arc:
+    start: Slight anxiety — "will it find/fetch the right template, and what if I'm offline?"
+    middle: Focused — watches the source get auto-detected and the clone (or cache hit) resolve
+    end: Confident — a correct template directory is staged; the familiar build proceeds unchanged
+steps:
+  - id: 1
+    name: Configure the template source (one-time)
+    command: 'set [cv] cv_template_path = <local-dir | git-url>; optional cv_template_ref, cv_template_auth, cv_template_cache'
+    shared_artifacts:
+      - name: template_source
+        source: "[cv] cv_template_path (auto-detected: local path vs git URL)"
+        consumers: ["source resolver", "clone/cache key"]
+    emotional_state: {entry: anxious, exit: focused}
+  - id: 2
+    name: Run insert (existing entry point) and auto-detect source type
+    command: rusty_cv_creator insert --job-title "<title>" --company-name "<co>" [--variant <v>]
+    integration_checkpoint: >-
+      cv_template_path classified as LOCAL (path exists / not a git URL) or GITHUB (git@... or https://....git). No new subcommand; sourcing is transparent.
+    failure_modes:
+      - "Value is neither a readable local dir nor a recognisable git URL -> fail fast with hint"
+    emotional_state: {entry: focused, exit: focused}
+  - id: 3
+    name: Obtain a local template directory
+    command: 'LOCAL -> use path directly | GITHUB -> clone/checkout <ref> into cache (or reuse cache)'
+    shared_artifacts:
+      - name: resolved_template_dir
+        source: "local path (LOCAL) | cache/<repo>@<ref> (GITHUB)"
+        consumers: ["copy_dir into dated working copy (existing prepare_path_for_new_cv)"]
+    failure_modes:
+      - "GITHUB fetch fails (offline/auth/bad-url) AND a cached clone exists -> reuse cache (warn)"
+      - "GITHUB fetch fails AND no cache -> abort with actionable hint (auth/network/url)"
+    emotional_state: {entry: focused, exit: focused}
+  - id: 4
+    name: Hand off to the existing build flow (unchanged downstream)
+    command: copy_dir(resolved_template_dir, dated working copy) -> just build <variant> -> file PDF
+    integration_checkpoint: >-
+      Downstream (variant resolve, build, per-year filing) is IDENTICAL to today; this feature only changes how resolved_template_dir is produced.
+    emotional_state: {entry: focused, exit: confident}
+integration_validation:
+  shared_artifact_consistency:
+    - artifact: resolved_template_dir
+      must_match_across: [3, 4]
+      failure_message: "The directory copied into the working copy must be the resolved (local or cached-git) template dir for the configured source+ref."

--- a/rusty-cv-config-example.ini
+++ b/rusty-cv-config-example.ini
@@ -1,10 +1,31 @@
 [cv]
-# Path to the CV template repository (git@github.com:chess-seventh/cv.git).
-# Its Justfile builds one PDF per role variant.
+# Path to the CV template — either a local directory (used as-is, today's
+# behaviour) or a git URL it is cloned from. Supported git URL forms:
+#   git@github.com:chess-seventh/cv.git    (SSH)
+#   https://github.com/chess-seventh/cv.git (HTTPS)
+# The template's Justfile builds one PDF per role variant.
 cv_template_path = "~/src/jobs_search/_cv_template"
 # Filename prefix shared by every variant driver/output: <prefix>-<variant>.{tex,pdf}
 # e.g. PivaFrancesco-senior-devops.tex -> PivaFrancesco-senior-devops.pdf
 cv_file_prefix = "PivaFrancesco"
+
+# ── Git template source — only used when cv_template_path is a git URL ──────────
+# Optional. Pin the template to a branch, tag, or commit SHA. When unset, the
+# repository's default branch is used. An unresolvable ref aborts (no silent
+# fallback to the default branch).
+# cv_template_ref = "v2.1"
+#
+# Optional. Clone transport: auto|ssh|token (default: auto, which infers ssh for
+# git@/ssh:// URLs and token otherwise). For token auth the token is read ONLY
+# from the GITHUB_TOKEN environment variable — never from this INI file, the git
+# command line, or the cached clone.
+# cv_template_auth = "auto"
+#
+# Optional. Directory where cloned templates are cached and reused (and reused
+# offline, with a warning, when the remote is unreachable). When the remote is
+# unreachable and no cache exists, the run aborts rather than build a partial CV.
+# Default: ~/.cache/rusty-cv-creator/templates
+# cv_template_cache = "~/.cache/rusty-cv-creator/templates"
 
 [variant]
 # Fallback variant used when none is passed via --variant and none can be

--- a/src/command_runner.rs
+++ b/src/command_runner.rs
@@ -1,6 +1,19 @@
 use std::io;
 use std::process::{Command, Stdio};
 
+/// Captured outcome of a subprocess run (UC-1, feature `template-source`):
+/// success plus both streams, so a caller can classify a git failure from its
+/// stderr (auth vs network/offline vs bad-ref). Additive to the port; existing
+/// `status`/`output`/`spawn` call sites are unaffected.
+// SCAFFOLD: true
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct CommandOutcome {
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+}
+
 /// Abstraction over running external programs so the build / view / Tailscale
 /// logic can be unit-tested with a fake instead of really shelling out.
 pub trait CommandRunner {
@@ -13,6 +26,22 @@ pub trait CommandRunner {
 
     /// Launch `program args...` detached (used for the PDF viewer).
     fn spawn(&self, program: &str, args: &[&str]) -> io::Result<()>;
+
+    /// UC-1 (feature `template-source`): run `program args...` (optionally in
+    /// `cwd`) capturing success + stdout + stderr, so a git failure can be
+    /// classified by inspecting stderr. Additive and backward-compatible — the
+    /// default body is a RED scaffold; existing implementors inherit it without
+    /// change and DELIVER provides the real captures.
+    // SCAFFOLD: true
+    #[allow(dead_code)]
+    fn run_capturing(
+        &self,
+        _program: &str,
+        _args: &[&str],
+        _cwd: Option<&str>,
+    ) -> io::Result<CommandOutcome> {
+        panic!("not yet implemented — RED scaffold (UC-1 stderr capture)")
+    }
 }
 
 /// The real runner, backed by `std::process::Command`.
@@ -132,5 +161,35 @@ pub mod testing {
     fn test_fake_runner_io_error() {
         let fake = FakeRunner::io_error();
         assert!(fake.spawn("zathura", &["a.pdf"]).is_err());
+    }
+}
+
+#[cfg(test)]
+mod uc1_specs {
+    //! DISTILL spec for UC-1 (feature `template-source`): the additive
+    //! stderr-capturing run. Pending DELIVER — calls the RED scaffold default
+    //! `run_capturing`, so it fails by `panic!` (RED), not by a compile error.
+    use super::CommandRunner;
+    use super::testing::FakeRunner;
+
+    /// @us-02 @in-memory
+    /// UC-1: a captured run exposes stderr so a git failure can be classified
+    /// into a distinct `TemplateSourceError` (auth vs network vs bad-ref).
+    #[test]
+    #[ignore = "pending DELIVER — UC-1"]
+    fn uc1_run_capturing_exposes_stderr() {
+        let runner = FakeRunner::failing();
+        let outcome = runner
+            .run_capturing(
+                "git",
+                &["clone", "git@github.com:chess-seventh/cv.git"],
+                None,
+            )
+            .expect("captured run should return an outcome, not an io error");
+        assert!(!outcome.success, "a failing clone reports success=false");
+        assert!(
+            !outcome.stderr.is_empty(),
+            "stderr must be captured so the failure can be classified"
+        );
     }
 }

--- a/src/command_runner.rs
+++ b/src/command_runner.rs
@@ -103,6 +103,7 @@ pub mod testing {
     pub struct FakeRunner {
         pub succeed: bool,
         pub stdout: String,
+        pub stderr: String,
         pub fail_io: bool,
         pub calls: RefCell<Vec<String>>,
     }
@@ -112,6 +113,7 @@ pub mod testing {
             Self {
                 succeed: true,
                 stdout: String::new(),
+                stderr: String::new(),
                 fail_io: false,
                 calls: RefCell::new(Vec::new()),
             }
@@ -120,6 +122,17 @@ pub mod testing {
         pub fn failing() -> Self {
             Self {
                 succeed: false,
+                ..Self::ok()
+            }
+        }
+
+        /// A failing runner whose captured `stderr` is the given string, so a
+        /// caller can assert the failure is classified by its stderr content
+        /// (auth vs bad-ref vs network) rather than by the single canned default.
+        pub fn failing_with_stderr(stderr: &str) -> Self {
+            Self {
+                succeed: false,
+                stderr: stderr.to_string(),
                 ..Self::ok()
             }
         }
@@ -178,8 +191,10 @@ pub mod testing {
             self.record(program, args);
             let stderr = if self.succeed {
                 String::new()
-            } else {
+            } else if self.stderr.is_empty() {
                 "fatal: could not read from remote repository.".to_string()
+            } else {
+                self.stderr.clone()
             };
             self.maybe_err(CommandOutcome {
                 success: self.succeed,

--- a/src/command_runner.rs
+++ b/src/command_runner.rs
@@ -5,7 +5,6 @@ use std::process::{Command, Stdio};
 /// success plus both streams, so a caller can classify a git failure from its
 /// stderr (auth vs network/offline vs bad-ref). Additive to the port; existing
 /// `status`/`output`/`spawn` call sites are unaffected.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct CommandOutcome {
     pub success: bool,
@@ -32,7 +31,6 @@ pub trait CommandRunner {
     /// implementors that capture stderr (e.g. `SystemRunner`) override this;
     /// the default is a best-effort delegation to `output` with empty stderr,
     /// so existing implementors keep compiling without change.
-    #[allow(dead_code)]
     fn run_capturing(
         &self,
         program: &str,

--- a/src/command_runner.rs
+++ b/src/command_runner.rs
@@ -5,7 +5,6 @@ use std::process::{Command, Stdio};
 /// success plus both streams, so a caller can classify a git failure from its
 /// stderr (auth vs network/offline vs bad-ref). Additive to the port; existing
 /// `status`/`output`/`spawn` call sites are unaffected.
-// SCAFFOLD: true
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct CommandOutcome {
@@ -29,18 +28,23 @@ pub trait CommandRunner {
 
     /// UC-1 (feature `template-source`): run `program args...` (optionally in
     /// `cwd`) capturing success + stdout + stderr, so a git failure can be
-    /// classified by inspecting stderr. Additive and backward-compatible — the
-    /// default body is a RED scaffold; existing implementors inherit it without
-    /// change and DELIVER provides the real captures.
-    // SCAFFOLD: true
+    /// classified by inspecting stderr. Additive and backward-compatible —
+    /// implementors that capture stderr (e.g. `SystemRunner`) override this;
+    /// the default is a best-effort delegation to `output` with empty stderr,
+    /// so existing implementors keep compiling without change.
     #[allow(dead_code)]
     fn run_capturing(
         &self,
-        _program: &str,
-        _args: &[&str],
+        program: &str,
+        args: &[&str],
         _cwd: Option<&str>,
     ) -> io::Result<CommandOutcome> {
-        panic!("not yet implemented — RED scaffold (UC-1 stderr capture)")
+        let (success, stdout) = self.output(program, args)?;
+        Ok(CommandOutcome {
+            success,
+            stdout,
+            stderr: String::new(),
+        })
     }
 }
 
@@ -70,11 +74,30 @@ impl CommandRunner for SystemRunner {
             .spawn()?;
         Ok(())
     }
+
+    fn run_capturing(
+        &self,
+        program: &str,
+        args: &[&str],
+        cwd: Option<&str>,
+    ) -> io::Result<CommandOutcome> {
+        let mut cmd = Command::new(program);
+        cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+        if let Some(dir) = cwd {
+            cmd.current_dir(dir);
+        }
+        let out = cmd.output()?;
+        Ok(CommandOutcome {
+            success: out.status.success(),
+            stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        })
+    }
 }
 
 #[cfg(test)]
 pub mod testing {
-    use super::{CommandRunner, io};
+    use super::{CommandOutcome, CommandRunner, io};
     use std::cell::RefCell;
 
     /// A configurable fake runner for tests. Records the programs invoked and
@@ -147,6 +170,25 @@ pub mod testing {
             self.record(program, args);
             self.maybe_err(())
         }
+
+        fn run_capturing(
+            &self,
+            program: &str,
+            args: &[&str],
+            _cwd: Option<&str>,
+        ) -> io::Result<CommandOutcome> {
+            self.record(program, args);
+            let stderr = if self.succeed {
+                String::new()
+            } else {
+                "fatal: could not read from remote repository.".to_string()
+            };
+            self.maybe_err(CommandOutcome {
+                success: self.succeed,
+                stdout: self.stdout.clone(),
+                stderr,
+            })
+        }
     }
 
     #[test]
@@ -176,7 +218,6 @@ mod uc1_specs {
     /// UC-1: a captured run exposes stderr so a git failure can be classified
     /// into a distinct `TemplateSourceError` (auth vs network vs bad-ref).
     #[test]
-    #[ignore = "pending DELIVER — UC-1"]
     fn uc1_run_capturing_exposes_stderr() {
         let runner = FakeRunner::failing();
         let outcome = runner

--- a/src/file_handlers.rs
+++ b/src/file_handlers.rs
@@ -2,6 +2,7 @@ use crate::command_runner::CommandRunner;
 use crate::config_parse::get_variable_from_config_file;
 use crate::global_conf::AppContext;
 use crate::helpers::{clean_string_from_quotes, fix_home_directory_path};
+use crate::template_source::detect_template_source;
 use chrono::{DateTime, Local};
 use log::{error, info, warn};
 use std::fs;
@@ -158,6 +159,7 @@ pub fn compile_cv(
 
 pub fn create_directory(
     ctx: &AppContext,
+    runner: &dyn CommandRunner,
     job_title: &str,
     company_name: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
@@ -176,14 +178,20 @@ pub fn create_directory(
         }
     }
 
-    let (cv_template_path, full_destination_path) =
-        match prepare_path_for_new_cv(ctx, job_title, company_name, &destination_folder, now) {
-            Ok(s) => s,
-            Err(e) => {
-                error!("{e:?}");
-                return Err(format!("{e:?}").to_string().into());
-            }
-        };
+    let (cv_template_path, full_destination_path) = match prepare_path_for_new_cv(
+        ctx,
+        runner,
+        job_title,
+        company_name,
+        &destination_folder,
+        now,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("{e:?}");
+            return Err(format!("{e:?}").to_string().into());
+        }
+    };
 
     match copy_dir::copy_dir(cv_template_path, full_destination_path.clone()) {
         Ok(_) => info!("✅ Directory created & copied successfully"),
@@ -202,6 +210,7 @@ pub fn remove_cv_dir(path_to_remove: &Path) -> std::io::Result<()> {
 
 fn prepare_path_for_new_cv(
     ctx: &AppContext,
+    runner: &dyn CommandRunner,
     job_title: &str,
     company_name: &str,
     destination_folder: &str,
@@ -209,7 +218,14 @@ fn prepare_path_for_new_cv(
 ) -> Result<(String, String), Box<dyn std::error::Error>> {
     let var = get_variable_from_config_file(ctx, "cv", "cv_template_path")?;
 
-    let cv_template_path: String = fix_home_directory_path(&var);
+    let configured_template: String = fix_home_directory_path(&var);
+
+    // D1/D7: auto-detect a local dir vs a git URL and resolve to a local dir.
+    // For a git source this clones into the cache via the CommandRunner port; for
+    // a local dir it is an unchanged passthrough (backward compat, TS-01/AC2).
+    let cache_dir = resolve_template_cache_dir(ctx);
+    let source = detect_template_source(&configured_template, &cache_dir)?;
+    let cv_template_path = source.resolve(runner)?;
 
     let formatted_job_title = sanitize_for_path(job_title);
     let formatted_company_name = sanitize_for_path(company_name);
@@ -223,6 +239,14 @@ fn prepare_path_for_new_cv(
     info!("✅ Copying from: {}", cv_template_path.clone());
 
     Ok((cv_template_path, full_destination_path))
+}
+
+/// Resolve the template cache directory: the optional `[cv] cv_template_cache`
+/// key, or the default `~/.cache/rusty-cv-creator/templates`. Only consulted for
+/// a git source; a local-dir source ignores it.
+fn resolve_template_cache_dir(ctx: &AppContext) -> String {
+    get_variable_from_config_file(ctx, "cv", "cv_template_cache")
+        .unwrap_or_else(|_| fix_home_directory_path("~/.cache/rusty-cv-creator/templates"))
 }
 
 fn prepare_year_dir(destination_folder: &String, now: &DateTime<Local>) -> Result<String, Error> {
@@ -463,6 +487,122 @@ mod tests {
         assert!(!sub.exists());
     }
 
+    /// Run a git command in `dir`, asserting success. Used only to build the
+    /// local "remote" fixture repository for the walking-skeleton test. Hooks are
+    /// disabled (`core.hooksPath` pointed at an empty dir) so the developer's
+    /// global git hooks cannot interfere with the hermetic fixture.
+    fn git_in(dir: &Path, empty_hooks: &Path, args: &[&str]) {
+        let ok = std::process::Command::new("git")
+            .current_dir(dir)
+            .arg("-c")
+            .arg(format!("core.hooksPath={}", empty_hooks.display()))
+            .args(args)
+            .status()
+            .unwrap()
+            .success();
+        assert!(ok, "git {args:?} failed");
+    }
+
+    // @walking_skeleton @driving_port
+    //
+    // Drives the new git-URL template path end-to-end through REAL layers: a real
+    // `SystemRunner` performs a real `git clone` from a local bare-ish repository
+    // exposed via a `file://` URL (deterministic, no network), real filesystem,
+    // real `copy_dir`. The substitution of a local repo for GitHub still exercises
+    // the genuine git shell-out mechanism — it is NOT a mock of the git layer.
+    //
+    // Observable outcome asserted: the git-sourced template's fixture files were
+    // resolved and copied into the dated working directory, ready to build. The
+    // costly LaTeX `just build` is intentionally NOT run here (pre-existing
+    // subsystem, out of scope for the skeleton's assertion).
+    //
+    // Serialized: the GitHub source's ADR-0004 git PATH check reads the global
+    // PATH, which the PATH-mutating test in `helpers` temporarily clobbers.
+    #[test]
+    #[serial_test::serial]
+    fn walking_skeleton_github_source_resolves_template_dir() {
+        let td = TempDir::new().unwrap();
+        let base = td.path();
+
+        // An empty hooks dir keeps the fixture repo isolated from global git hooks.
+        let empty_hooks = base.join("empty-hooks");
+        fs::create_dir_all(&empty_hooks).unwrap();
+
+        // 1) A local "remote" git repo holding the template fixture files.
+        let remote = base.join("remote-template");
+        fs::create_dir_all(&remote).unwrap();
+        fs::write(remote.join("TestCV-senior-devops.tex"), "template-body").unwrap();
+        fs::write(remote.join("Justfile"), "build:\n\techo build\n").unwrap();
+        git_in(&remote, &empty_hooks, &["init", "-q"]);
+        git_in(&remote, &empty_hooks, &["add", "."]);
+        git_in(
+            &remote,
+            &empty_hooks,
+            &[
+                "-c",
+                "user.email=test@example.com",
+                "-c",
+                "user.name=test",
+                "commit",
+                "-q",
+                "-m",
+                "init",
+            ],
+        );
+
+        let cache = base.join("cache");
+        let dest = base.join("dest");
+        let out = base.join("out");
+        fs::create_dir_all(&dest).unwrap();
+
+        let remote_url = format!("file://{}", remote.display());
+        let ini = format!(
+            "[cv]\ncv_template_path = \"{url}\"\ncv_template_cache = \"{cache}\"\n\
+             cv_file_prefix = \"TestCV\"\n\
+             [destination]\ncv_path = \"{dest}\"\noutput_pdf = \"{out}\"\n\
+             [db]\nengine = \"sqlite\"\ndb_file = \"x.db\"\n",
+            url = remote_url,
+            cache = cache.display(),
+            dest = dest.display(),
+            out = out.display()
+        );
+        let ini_path = base.join("conf.ini");
+        fs::write(&ini_path, ini).unwrap();
+
+        let ui = crate::cli_structure::UserInput {
+            action: crate::cli_structure::UserAction::Insert(
+                crate::cli_structure::FilterArgs::default(),
+            ),
+            save_to_database: false,
+            view_generated_cv: false,
+            dry_run: false,
+            config_ini: ini_path.to_str().unwrap().to_string(),
+            engine: "sqlite".to_string(),
+        };
+        let ctx = crate::config_parse::build_context(&ui);
+
+        // 2) Drive the real entry point: detect git URL -> real clone -> copy_dir.
+        let created = create_directory(
+            &ctx,
+            &crate::command_runner::SystemRunner,
+            "Senior DevOps",
+            "ACME",
+        )
+        .unwrap();
+
+        // 3) The git-sourced template landed in the working dir, ready to build.
+        assert!(
+            Path::new(&created)
+                .join("TestCV-senior-devops.tex")
+                .is_file(),
+            "cloned template .tex should be copied into the working dir"
+        );
+        assert!(
+            Path::new(&created).join("Justfile").is_file(),
+            "cloned template Justfile should be copied into the working dir"
+        );
+    }
+
     #[test]
     fn test_create_directory_and_remove_flow() {
         let td = TempDir::new().unwrap();
@@ -498,7 +638,8 @@ mod tests {
         let ctx = crate::config_parse::build_context(&ui);
 
         // create_directory copies the template into a dated dir under dest.
-        let created = create_directory(&ctx, "Senior DevOps", "ACME").unwrap();
+        let runner = crate::command_runner::testing::FakeRunner::ok();
+        let created = create_directory(&ctx, &runner, "Senior DevOps", "ACME").unwrap();
         assert!(
             Path::new(&created)
                 .join("TestCV-senior-devops.tex")

--- a/src/file_handlers.rs
+++ b/src/file_handlers.rs
@@ -2,7 +2,7 @@ use crate::command_runner::CommandRunner;
 use crate::config_parse::get_variable_from_config_file;
 use crate::global_conf::AppContext;
 use crate::helpers::{clean_string_from_quotes, fix_home_directory_path};
-use crate::template_source::detect_template_source;
+use crate::template_source::{AuthMode, resolve_template_for_config};
 use chrono::{DateTime, Local};
 use log::{error, info, warn};
 use std::fs;
@@ -221,11 +221,21 @@ fn prepare_path_for_new_cv(
     let configured_template: String = fix_home_directory_path(&var);
 
     // D1/D7: auto-detect a local dir vs a git URL and resolve to a local dir.
-    // For a git source this clones into the cache via the CommandRunner port; for
-    // a local dir it is an unchanged passthrough (backward compat, TS-01/AC2).
+    // A git source resolves through the cache executor (probe → decide →
+    // clone / fetch / reuse-stale / abort), threading the optional ref (TS-03)
+    // and auth (TS-02). A local dir is an unchanged passthrough (backward compat,
+    // TS-01/AC2). For token auth the secret is read from the GITHUB_TOKEN
+    // environment variable via the askpass indirection — never from the INI.
     let cache_dir = resolve_template_cache_dir(ctx);
-    let source = detect_template_source(&configured_template, &cache_dir)?;
-    let cv_template_path = source.resolve(runner)?;
+    let git_ref = get_variable_from_config_file(ctx, "cv", "cv_template_ref").ok();
+    let auth = resolve_template_auth(ctx)?;
+    let cv_template_path = resolve_template_for_config(
+        &configured_template,
+        &cache_dir,
+        git_ref.as_deref(),
+        auth,
+        runner,
+    )?;
 
     let formatted_job_title = sanitize_for_path(job_title);
     let formatted_company_name = sanitize_for_path(company_name);
@@ -247,6 +257,17 @@ fn prepare_path_for_new_cv(
 fn resolve_template_cache_dir(ctx: &AppContext) -> String {
     get_variable_from_config_file(ctx, "cv", "cv_template_cache")
         .unwrap_or_else(|_| fix_home_directory_path("~/.cache/rusty-cv-creator/templates"))
+}
+
+/// Resolve the auth transport from the optional `[cv] cv_template_auth` key
+/// (`auto|ssh|token`); an absent key defaults to `auto`. The secret token itself
+/// is never read from the INI — only from the `GITHUB_TOKEN` environment variable
+/// via the askpass indirection (ADR-0008).
+fn resolve_template_auth(ctx: &AppContext) -> Result<AuthMode, Box<dyn std::error::Error>> {
+    match get_variable_from_config_file(ctx, "cv", "cv_template_auth") {
+        Ok(value) => Ok(AuthMode::from_config(&value)?),
+        Err(_) => Ok(AuthMode::Auto),
+    }
 }
 
 fn prepare_year_dir(destination_folder: &String, now: &DateTime<Local>) -> Result<String, Error> {

--- a/src/file_handlers.rs
+++ b/src/file_handlers.rs
@@ -592,7 +592,7 @@ mod tests {
 
         let ui = crate::cli_structure::UserInput {
             action: crate::cli_structure::UserAction::Insert(
-                crate::cli_structure::FilterArgs::default(),
+                crate::cli_structure::InsertArgs::default(),
             ),
             save_to_database: false,
             view_generated_cv: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod cv_insert;
 mod file_handlers;
 mod global_conf;
 mod helpers;
+mod template_source;
 mod user_action;
 
 use crate::cli_structure::{UserAction, UserInput, match_user_action};
@@ -82,7 +83,7 @@ fn prepare_cv(
     // Pre-usage check: the builder (`just`) drives `tectonic` via the Justfile.
     ensure_tools_available(&[cfg.builder.as_str(), "tectonic"])?;
 
-    let created_cv_dir = match create_directory(ctx, job_title, company_name) {
+    let created_cv_dir = match create_directory(ctx, runner, job_title, company_name) {
         Ok(s) => s,
         Err(e) => {
             error!("Could not create directory for CV: {e:?}");

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -13,7 +13,7 @@
 //! cache reuse / offline fallback (TS-04) are later slices and intentionally
 //! absent here.
 
-use crate::command_runner::CommandRunner;
+use crate::command_runner::{CommandOutcome, CommandRunner};
 use crate::helpers::ensure_tools_available;
 use log::info;
 use std::fs;
@@ -51,6 +51,7 @@ pub struct GitHubRepository {
     url: String,
     cache_dir: String,
     auth: AuthMode,
+    git_ref: Option<String>,
 }
 
 impl GitHubRepository {
@@ -59,6 +60,7 @@ impl GitHubRepository {
             url,
             cache_dir,
             auth: AuthMode::Auto,
+            git_ref: None,
         }
     }
 
@@ -361,10 +363,10 @@ impl TemplateCache {
 impl GitHubRepository {
     /// Pin the template to a branch/tag/SHA (TS-03). Additive builder; the
     /// skeleton's default-branch `new`/`resolve` are unchanged.
-    // SCAFFOLD: true
     #[allow(dead_code)]
-    pub fn with_ref(self, _git_ref: &str) -> Self {
-        panic!("not yet implemented — RED scaffold")
+    pub fn with_ref(mut self, git_ref: &str) -> Self {
+        self.git_ref = Some(git_ref.to_string());
+        self
     }
 
     /// Select the auth transport (TS-02). Additive builder; the skeleton's
@@ -379,11 +381,13 @@ impl GitHubRepository {
     /// (TS-02). Distinct from the skeleton's `resolve`, which stays the green
     /// default-branch happy path (TS-01/AC1).
     ///
-    /// Partial: cache reuse (TS-04) and ref pinning (TS-03) wiring lands in
-    /// later slices. Here it prepends the auth flags to the git invocation
-    /// through `CommandRunner` and classifies a clone failure from its captured
-    /// stderr. The SSH path adds no askpass flag — the agent is inherited.
-    // SCAFFOLD: true
+    /// Cache reuse (TS-04) wiring lands in a later slice. Here it prepends the
+    /// auth flags to the git invocation through `CommandRunner` and classifies a
+    /// clone failure from its captured stderr. The SSH path adds no askpass flag
+    /// — the agent is inherited. When a ref is pinned (TS-03) the cloned repo is
+    /// explicitly checked out at that ref and its resolved SHA logged; an
+    /// unresolvable ref aborts via `BadRef` with NO silent default-branch
+    /// fallback. An unset ref preserves the skeleton's default-branch resolve.
     #[allow(dead_code)]
     pub fn resolve_classified(
         &self,
@@ -407,7 +411,65 @@ impl GitHubRepository {
             return Err(classify_git_stderr(&outcome.stderr, &self.url, None));
         }
 
+        if let Some(git_ref) = &self.git_ref {
+            self.checkout_pinned_ref(runner, &destination, git_ref)?;
+        }
+
         Ok(destination)
+    }
+
+    /// Explicitly check out `git_ref` in the freshly cloned `destination`, then
+    /// log the resolved SHA via `git rev-parse HEAD` (detached-HEAD safe — a SHA
+    /// checkout leaves a detached HEAD, so branch state is never relied upon). A
+    /// failing checkout or rev-parse is classified from its captured stderr into
+    /// `BadRef` and aborts — never a silent fallback to the default branch
+    /// (TS-03/AC3).
+    fn checkout_pinned_ref(
+        &self,
+        runner: &dyn CommandRunner,
+        destination: &str,
+        git_ref: &str,
+    ) -> Result<(), TemplateSourceError> {
+        let checkout = self.run_in_clone(runner, &["checkout", git_ref], destination, git_ref)?;
+        if !checkout.success {
+            return Err(classify_git_stderr(
+                &checkout.stderr,
+                &self.url,
+                Some(git_ref),
+            ));
+        }
+
+        let resolved = self.run_in_clone(runner, &["rev-parse", "HEAD"], destination, git_ref)?;
+        if !resolved.success {
+            return Err(classify_git_stderr(
+                &resolved.stderr,
+                &self.url,
+                Some(git_ref),
+            ));
+        }
+
+        info!(
+            "✅ Pinned template to ref '{git_ref}' (resolved SHA: {})",
+            resolved.stdout.trim()
+        );
+        Ok(())
+    }
+
+    /// Run a git subcommand inside the cloned `destination`, mapping a captured
+    /// io failure to `BadRef` so a pinned-ref resolve never silently degrades.
+    fn run_in_clone(
+        &self,
+        runner: &dyn CommandRunner,
+        args: &[&str],
+        destination: &str,
+        git_ref: &str,
+    ) -> Result<CommandOutcome, TemplateSourceError> {
+        runner
+            .run_capturing("git", args, Some(destination))
+            .map_err(|_| TemplateSourceError::BadRef {
+                url: self.url.clone(),
+                git_ref: git_ref.to_string(),
+            })
     }
 }
 
@@ -616,7 +678,6 @@ mod distill_specs {
     /// logged — detached-HEAD safe).
     #[test]
     #[serial_test::serial]
-    #[ignore = "pending DELIVER — TS-03"]
     fn ts03_ac1_pinned_ref_is_checked_out() {
         let td = TempDir::new().unwrap();
         let cache = td.path().to_str().unwrap().to_string();

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -883,10 +883,15 @@ mod distill_specs {
                 flags.iter().any(|f| f == &expected),
                 "token auth must point git at the fixed askpass helper constant"
             );
-            prop_assert!(
-                !flags.iter().any(|f| f.contains(host.as_str()) || f.contains(name.as_str())),
-                "the helper name must be input-independent — no url fragment in the flags"
-            );
+            // Input-independence is the real property: Token flags never vary with
+            // the url, so no url-derived fragment can leak in. Assert that invariant
+            // directly. (A substring check on the random host/name false-fails when
+            // it collides with the fixed helper constant's own letters — e.g. a
+            // generated "git"/"env"/"ask" is a substring of `core.askpass=
+            // git-askpass-from-env` — which made this test flaky under proptest.)
+            let baseline =
+                auth_invocation_flags(AuthMode::Token, "https://baseline.example/owner/repo.git");
+            prop_assert_eq!(&flags, &baseline, "token flags must be identical regardless of the url");
         });
     }
 

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -50,11 +50,16 @@ impl TemplateSource for LocalDirectory {
 pub struct GitHubRepository {
     url: String,
     cache_dir: String,
+    auth: AuthMode,
 }
 
 impl GitHubRepository {
     pub fn new(url: String, cache_dir: String) -> Self {
-        Self { url, cache_dir }
+        Self {
+            url,
+            cache_dir,
+            auth: AuthMode::Auto,
+        }
     }
 
     /// Deterministic per-repository sub-directory of the cache dir. Cache keying
@@ -155,11 +160,19 @@ pub enum AuthMode {
 }
 
 impl AuthMode {
-    /// Parse the optional `[cv] cv_template_auth` value (`auto|ssh|token`).
-    // SCAFFOLD: true
+    /// Parse the optional `[cv] cv_template_auth` value (`auto|ssh|token`). An
+    /// unknown value fails fast as a typed `TemplateSourceError::BadValue`
+    /// naming the offending value — never a silent default (TS-02/AC3).
     #[allow(dead_code)]
-    pub fn from_config(_value: &str) -> Result<AuthMode, TemplateSourceError> {
-        panic!("not yet implemented — RED scaffold")
+    pub fn from_config(value: &str) -> Result<AuthMode, TemplateSourceError> {
+        match value {
+            "auto" => Ok(AuthMode::Auto),
+            "ssh" => Ok(AuthMode::Ssh),
+            "token" => Ok(AuthMode::Token),
+            other => Err(TemplateSourceError::BadValue {
+                value: other.to_string(),
+            }),
+        }
     }
 
     /// Human-facing name used in error hints (never the secret token value).
@@ -182,13 +195,29 @@ impl AuthMode {
     }
 }
 
-/// Pure (TS-02/AC2): the extra `git -c` flags needed for `auth` against `url`.
-/// For `Token` this is a `core.askpass` helper invocation; the secret value
-/// itself never appears in the returned flags (asserted by the specs).
-// SCAFFOLD: true
+/// Name of the askpass helper git is pointed at for token auth. The helper reads
+/// `GITHUB_TOKEN` from the environment and prints it on stdout when git asks for
+/// a password, so the secret value never reaches the argv, the INI, or the cache
+/// repo's `.git/config` (TS-D3 / ADR-0008). The resolver materialises this
+/// executable on disk (step 04-02); only the indirection is named here.
+const ASKPASS_HELPER: &str = "git-askpass-from-env";
+
+/// Pure total fn (TS-02/AC2) over (`AuthMode` × url-scheme): the extra `git -c`
+/// flags needed for `auth` against `url`.
+///
+/// * `Auto`  infers the transport from the url scheme (a `git@…`/`ssh://…`
+///   remote inherits the SSH agent; anything else uses a token).
+/// * `Ssh`   adds no flags — the agent is inherited from the ambient environment
+///   (SPIKE-proven against the real private repo).
+/// * `Token` routes through a `core.askpass` helper that reads `GITHUB_TOKEN`
+///   from the environment; the secret VALUE never appears in the returned flags.
 #[allow(dead_code)]
-pub fn auth_invocation_flags(_auth: AuthMode, _url: &str) -> Vec<String> {
-    panic!("not yet implemented — RED scaffold")
+pub fn auth_invocation_flags(auth: AuthMode, url: &str) -> Vec<String> {
+    match auth {
+        AuthMode::Auto => auth_invocation_flags(AuthMode::inferred_from_url(url), url),
+        AuthMode::Ssh => Vec::new(),
+        AuthMode::Token => vec!["-c".to_string(), format!("core.askpass={ASKPASS_HELPER}")],
+    }
 }
 
 /// Typed failure classes (TS-D1). Distinct variants so the resolver emits a
@@ -338,23 +367,47 @@ impl GitHubRepository {
         panic!("not yet implemented — RED scaffold")
     }
 
-    /// Select the auth transport (TS-02). Additive.
-    // SCAFFOLD: true
+    /// Select the auth transport (TS-02). Additive builder; the skeleton's
+    /// default-branch `new`/`resolve` are unchanged.
     #[allow(dead_code)]
-    pub fn with_auth(self, _auth: AuthMode) -> Self {
-        panic!("not yet implemented — RED scaffold")
+    pub fn with_auth(mut self, auth: AuthMode) -> Self {
+        self.auth = auth;
+        self
     }
 
-    /// Resolve with cache reuse, ref pinning, auth, and typed failure
-    /// classification (TS-02/03/04). Distinct from the skeleton's `resolve`,
-    /// which stays the green default-branch happy path (TS-01/AC1).
+    /// Resolve with auth-routed clone and typed failure classification
+    /// (TS-02). Distinct from the skeleton's `resolve`, which stays the green
+    /// default-branch happy path (TS-01/AC1).
+    ///
+    /// Partial: cache reuse (TS-04) and ref pinning (TS-03) wiring lands in
+    /// later slices. Here it prepends the auth flags to the git invocation
+    /// through `CommandRunner` and classifies a clone failure from its captured
+    /// stderr. The SSH path adds no askpass flag — the agent is inherited.
     // SCAFFOLD: true
     #[allow(dead_code)]
     pub fn resolve_classified(
         &self,
-        _runner: &dyn CommandRunner,
+        runner: &dyn CommandRunner,
     ) -> Result<String, TemplateSourceError> {
-        panic!("not yet implemented — RED scaffold")
+        let flags = auth_invocation_flags(self.auth, &self.url);
+        let destination = self.clone_destination();
+
+        let mut args: Vec<&str> = flags.iter().map(String::as_str).collect();
+        args.push("clone");
+        args.push(&self.url);
+        args.push(&destination);
+
+        let outcome = runner.run_capturing("git", &args, None).map_err(|_| {
+            TemplateSourceError::NetworkOffline {
+                url: self.url.clone(),
+            }
+        })?;
+
+        if !outcome.success {
+            return Err(classify_git_stderr(&outcome.stderr, &self.url, None));
+        }
+
+        Ok(destination)
     }
 }
 
@@ -484,7 +537,6 @@ mod distill_specs {
     /// askpass / token machinery on the SSH path.
     #[test]
     #[serial_test::serial]
-    #[ignore = "pending DELIVER — TS-02"]
     fn ts02_ac1_ssh_source_clones_via_git_at_url() {
         let td = TempDir::new().unwrap();
         let cache = td.path().to_str().unwrap().to_string();
@@ -506,7 +558,6 @@ mod distill_specs {
     /// TS-02/AC2: the token is taken from the environment and fed via
     /// `core.askpass`; it never appears on the git command line.
     #[test]
-    #[ignore = "pending DELIVER — TS-02"]
     fn ts02_ac2_token_uses_askpass_and_never_on_argv() {
         let flags =
             auth_invocation_flags(AuthMode::Token, "https://github.com/chess-seventh/cv.git");
@@ -520,6 +571,29 @@ mod distill_specs {
                 .any(|f| f.contains("x-access-token") || f.contains("ghp_")),
             "the token value must never appear in the git argv"
         );
+    }
+
+    /// @us-02 @property
+    /// TS-02/AC2 (strengthened): secret-absence invariant. For ANY GITHUB_TOKEN
+    /// value and ANY https remote, the returned token-auth flags route through
+    /// `core.askpass` yet never embed the secret — the flags are computed
+    /// independently of the token, which stays in the environment and reaches
+    /// git only via the askpass indirection.
+    #[test]
+    fn ts02_ac2_secret_value_never_embedded_in_flags() {
+        use proptest::prelude::*;
+        proptest!(|(token in "ghp_[A-Za-z0-9]{20,40}", name in "[a-z]{3,10}")| {
+            let url = format!("https://github.com/chess-seventh/{name}.git");
+            let flags = auth_invocation_flags(AuthMode::Token, &url);
+            prop_assert!(
+                flags.iter().any(|f| f.contains("core.askpass")),
+                "token auth must route through core.askpass"
+            );
+            prop_assert!(
+                !flags.iter().any(|f| f.contains(&token)),
+                "the generated token value must never appear in the returned flags"
+            );
+        });
     }
 
     /// @us-02 @error

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -134,6 +134,155 @@ fn is_git_url(value: &str) -> bool {
         || (value.starts_with("https://") && value.ends_with(".git"))
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// DISTILL RED scaffolds — slices TS-02 (auth), TS-03 (ref pinning),
+// TS-04 (cache/offline) and TS-D1 (typed errors). ADDITIVE ONLY: the green
+// skeleton above (`LocalDirectory`, `GitHubRepository::new`/`resolve`,
+// `detect_template_source`, `is_git_url`) is untouched. Every body `panic!`s so
+// the pending specs in `mod distill_specs` classify RED (not BROKEN). DELIVER
+// replaces these bodies. Detect markers: `// SCAFFOLD: true`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Auth transport (TS-D3, TS-02). Inferred from the URL scheme by default;
+/// `token` reads `GITHUB_TOKEN` from the environment and feeds git via
+/// `core.askpass` — never the INI, the argv, or the cache `.git/config`.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMode {
+    Auto,
+    Ssh,
+    Token,
+}
+
+impl AuthMode {
+    /// Parse the optional `[cv] cv_template_auth` value (`auto|ssh|token`).
+    // SCAFFOLD: true
+    #[allow(dead_code)]
+    pub fn from_config(_value: &str) -> Result<AuthMode, TemplateSourceError> {
+        panic!("not yet implemented — RED scaffold")
+    }
+}
+
+/// Pure (TS-02/AC2): the extra `git -c` flags needed for `auth` against `url`.
+/// For `Token` this is a `core.askpass` helper invocation; the secret value
+/// itself never appears in the returned flags (asserted by the specs).
+// SCAFFOLD: true
+#[allow(dead_code)]
+pub fn auth_invocation_flags(_auth: AuthMode, _url: &str) -> Vec<String> {
+    panic!("not yet implemented — RED scaffold")
+}
+
+/// Typed failure classes (TS-D1). Distinct variants so the resolver emits a
+/// distinct actionable hint per failure by `match`, never by string-compare.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum TemplateSourceError {
+    /// Auth rejected (e.g. SSH publickey / bad token) — TS-02/AC3.
+    Auth { url: String, mode: AuthMode },
+    /// Remote unreachable / offline with no usable cache — TS-04.
+    NetworkOffline { url: String },
+    /// The pinned ref does not resolve in the repo — TS-03/AC3.
+    BadRef { url: String, git_ref: String },
+    /// No cache for `repo@ref` and the fetch failed — TS-04/AC2.
+    NoCache { repo_ref: String },
+    /// Value is neither a readable directory nor a git URL — TS-01/AC3.
+    BadValue { value: String },
+}
+
+impl std::fmt::Display for TemplateSourceError {
+    // SCAFFOLD: true
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        panic!("not yet implemented — RED scaffold")
+    }
+}
+
+impl std::error::Error for TemplateSourceError {}
+
+/// Pure (UC-1): map git's stderr to a typed failure class, so auth vs
+/// network/offline vs bad-ref each get a distinct hint (TS-02/AC3, TS-03/AC3).
+// SCAFFOLD: true
+#[allow(dead_code)]
+pub fn classify_git_stderr(
+    _stderr: &str,
+    _url: &str,
+    _git_ref: Option<&str>,
+) -> TemplateSourceError {
+    panic!("not yet implemented — RED scaffold")
+}
+
+/// Pure reuse-vs-fetch-vs-abort decision (TS-D2, TS-04). A total function over
+/// (cache-entry-present, remote-reachable) — never panics once implemented.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheAction {
+    /// No entry yet — full clone.
+    Clone,
+    /// Entry present and remote reachable — fetch + checkout (the perf lever).
+    FetchCheckout,
+    /// Remote unreachable but a usable entry exists — reuse it offline (warn).
+    ReuseStale,
+    /// Remote unreachable and no entry — abort fast, no partial CV.
+    Abort,
+}
+
+/// Owns cache-key derivation and the pure cache decision (TS-D2). Only the
+/// executor writes, and its write universe is bounded to the cache dir.
+#[allow(dead_code)]
+pub struct TemplateCache {
+    cache_dir: String,
+}
+
+impl TemplateCache {
+    #[allow(dead_code)]
+    pub fn new(cache_dir: String) -> Self {
+        Self { cache_dir }
+    }
+
+    /// Deterministic sanitised cache key for `repo@ref`. Pure — same input maps
+    /// to the same key (PBT in `mod distill_specs`).
+    // SCAFFOLD: true
+    #[allow(dead_code)]
+    pub fn cache_key(&self, _url: &str, _git_ref: Option<&str>) -> String {
+        panic!("not yet implemented — RED scaffold")
+    }
+
+    /// Pure decision over (entry-exists, remote-reachable) — the TS-04 matrix.
+    // SCAFFOLD: true
+    #[allow(dead_code)]
+    pub fn decide(&self, _entry_exists: bool, _remote_reachable: bool) -> CacheAction {
+        panic!("not yet implemented — RED scaffold")
+    }
+}
+
+impl GitHubRepository {
+    /// Pin the template to a branch/tag/SHA (TS-03). Additive builder; the
+    /// skeleton's default-branch `new`/`resolve` are unchanged.
+    // SCAFFOLD: true
+    #[allow(dead_code)]
+    pub fn with_ref(self, _git_ref: &str) -> Self {
+        panic!("not yet implemented — RED scaffold")
+    }
+
+    /// Select the auth transport (TS-02). Additive.
+    // SCAFFOLD: true
+    #[allow(dead_code)]
+    pub fn with_auth(self, _auth: AuthMode) -> Self {
+        panic!("not yet implemented — RED scaffold")
+    }
+
+    /// Resolve with cache reuse, ref pinning, auth, and typed failure
+    /// classification (TS-02/03/04). Distinct from the skeleton's `resolve`,
+    /// which stays the green default-branch happy path (TS-01/AC1).
+    // SCAFFOLD: true
+    #[allow(dead_code)]
+    pub fn resolve_classified(
+        &self,
+        _runner: &dyn CommandRunner,
+    ) -> Result<String, TemplateSourceError> {
+        panic!("not yet implemented — RED scaffold")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,5 +384,173 @@ mod tests {
             Ok(_) => panic!("unrecognised value should not resolve to a source"),
             Err(err) => assert!(err.to_string().contains("not-a-dir-nor-url")),
         }
+    }
+}
+
+#[cfg(test)]
+mod distill_specs {
+    //! DISTILL specifications for slices TS-02/03/04, mapped from the `.feature`
+    //! SSOT under `tests/acceptance/template-source/`. These live in-crate (not in
+    //! an external `tests/` file) because `TemplateSource`, the scaffolds, and
+    //! `command_runner::testing::FakeRunner` are binary-private — they are NOT on
+    //! the `lib.rs` facade (only `database`/`models`/`schema`/`tui` are), so an
+    //! external integration crate cannot reach them. This matches the existing
+    //! green precedent (`mod tests` above). Pending specs are `#[ignore]`d
+    //! one-at-a-time for DELIVER; un-ignored they fail by `panic!` (RED), not by a
+    //! compile/import error.
+    use super::*;
+    use crate::command_runner::testing::FakeRunner;
+    use tempfile::TempDir;
+
+    // ── TS-02 — private repo / auth ──────────────────────────────────────────
+
+    /// @us-02 @in-memory
+    /// TS-02/AC1: an SSH source clones over its `git@…` URL using the agent — no
+    /// askpass / token machinery on the SSH path.
+    #[test]
+    #[serial_test::serial]
+    #[ignore = "pending DELIVER — TS-02"]
+    fn ts02_ac1_ssh_source_clones_via_git_at_url() {
+        let td = TempDir::new().unwrap();
+        let cache = td.path().to_str().unwrap().to_string();
+        let runner = FakeRunner::ok();
+        let source = GitHubRepository::new("git@github.com:chess-seventh/cv.git".into(), cache)
+            .with_auth(AuthMode::Ssh);
+
+        source.resolve_classified(&runner).unwrap();
+
+        let recorded = &runner.calls.borrow()[0];
+        assert!(recorded.starts_with("git clone git@github.com:chess-seventh/cv.git"));
+        assert!(
+            !recorded.contains("askpass"),
+            "the SSH path must not use askpass"
+        );
+    }
+
+    /// @us-02 @in-memory @error
+    /// TS-02/AC2: the token is taken from the environment and fed via
+    /// `core.askpass`; it never appears on the git command line.
+    #[test]
+    #[ignore = "pending DELIVER — TS-02"]
+    fn ts02_ac2_token_uses_askpass_and_never_on_argv() {
+        let flags =
+            auth_invocation_flags(AuthMode::Token, "https://github.com/chess-seventh/cv.git");
+        assert!(
+            flags.iter().any(|f| f.contains("core.askpass")),
+            "token auth must route through core.askpass"
+        );
+        assert!(
+            !flags
+                .iter()
+                .any(|f| f.contains("x-access-token") || f.contains("ghp_")),
+            "the token value must never appear in the git argv"
+        );
+    }
+
+    /// @us-02 @error
+    /// TS-02/AC3: an auth-failure stderr is classified as a distinct `Auth` error
+    /// (separate from a network/offline error).
+    #[test]
+    #[ignore = "pending DELIVER — TS-02"]
+    fn ts02_ac3_auth_failure_stderr_classified_as_auth() {
+        let err = classify_git_stderr(
+            "git@github.com: Permission denied (publickey).",
+            "git@github.com:chess-seventh/cv.git",
+            None,
+        );
+        assert!(matches!(err, TemplateSourceError::Auth { .. }));
+    }
+
+    // ── TS-03 — ref pinning ──────────────────────────────────────────────────
+
+    /// @us-03 @in-memory
+    /// TS-03/AC1: a pinned ref is explicitly checked out (its resolved SHA is then
+    /// logged — detached-HEAD safe).
+    #[test]
+    #[serial_test::serial]
+    #[ignore = "pending DELIVER — TS-03"]
+    fn ts03_ac1_pinned_ref_is_checked_out() {
+        let td = TempDir::new().unwrap();
+        let cache = td.path().to_str().unwrap().to_string();
+        let runner = FakeRunner::ok();
+        let source = GitHubRepository::new("https://github.com/chess-seventh/cv.git".into(), cache)
+            .with_ref("v2.1");
+
+        source.resolve_classified(&runner).unwrap();
+
+        assert!(
+            runner
+                .calls
+                .borrow()
+                .iter()
+                .any(|c| c.contains("checkout v2.1")),
+            "the pinned ref must be checked out explicitly"
+        );
+    }
+
+    /// @us-03 @error
+    /// TS-03/AC3: an unknown ref is classified as `BadRef` — the resolver aborts,
+    /// it does NOT silently fall back to the default branch.
+    #[test]
+    #[ignore = "pending DELIVER — TS-03"]
+    fn ts03_ac3_bad_ref_classified_no_silent_fallback() {
+        let err = classify_git_stderr(
+            "fatal: couldn't find remote ref does-not-exist",
+            "https://github.com/chess-seventh/cv.git",
+            Some("does-not-exist"),
+        );
+        assert!(matches!(err, TemplateSourceError::BadRef { .. }));
+    }
+
+    // ── TS-04 — cache / offline (the CacheAction matrix) ─────────────────────
+
+    /// @us-04 @property
+    /// TS-04/AC1+AC2+AC3: the reuse-vs-fetch-vs-abort decision is total over
+    /// (cache-entry-present, remote-reachable).
+    #[test]
+    #[ignore = "pending DELIVER — TS-04"]
+    fn ts04_cache_action_matrix() {
+        let cache = TemplateCache::new("/unused/cache".into());
+        assert_eq!(cache.decide(false, true), CacheAction::Clone); // AC3: fresh clone
+        assert_eq!(cache.decide(true, true), CacheAction::FetchCheckout); // AC3: update
+        assert_eq!(cache.decide(true, false), CacheAction::ReuseStale); // AC1: offline reuse
+        assert_eq!(cache.decide(false, false), CacheAction::Abort); // AC2: hard abort
+    }
+
+    /// @us-04 @property @edge
+    /// A repository and ref map to one deterministic cache entry (same input →
+    /// same key).
+    #[test]
+    #[ignore = "pending DELIVER — TS-04"]
+    fn ts04_cache_key_is_deterministic() {
+        use proptest::prelude::*;
+        let cache = TemplateCache::new("/unused/cache".into());
+        proptest!(|(url in "[a-z]{3,12}",
+                    git_ref in proptest::option::of("[a-z0-9]{1,8}"))| {
+            let r = git_ref.as_deref();
+            prop_assert_eq!(cache.cache_key(&url, r), cache.cache_key(&url, r));
+        });
+    }
+
+    // ── TS-01 — URL detection property (GREEN: `is_git_url` is implemented) ───
+
+    /// @us-01 @property @edge
+    /// Every recognised URL form (the two D1 GitHub forms plus the `file://`
+    /// superset) classifies as a git source; a bare token or a bare local path
+    /// does not.
+    #[test]
+    fn ts01_is_git_url_classifies_known_forms() {
+        use proptest::prelude::*;
+        proptest!(|(name in "[a-z]{3,10}")| {
+            let ssh = format!("git@github.com:chess-seventh/{}.git", name);
+            let https = format!("https://github.com/chess-seventh/{}.git", name);
+            let file_remote = format!("file:///tmp/{}", name);
+            let local_path = format!("/home/{}/templates/cv", name);
+            prop_assert!(is_git_url(&ssh));
+            prop_assert!(is_git_url(&https));
+            prop_assert!(is_git_url(&file_remote));
+            prop_assert!(!is_git_url(&name)); // bare token
+            prop_assert!(!is_git_url(&local_path)); // local path
+        });
     }
 }

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -251,6 +251,9 @@ pub enum TemplateSourceError {
     NoCache { repo_ref: String },
     /// Value is neither a readable directory nor a git URL — TS-01/AC3.
     BadValue { value: String },
+    /// A local filesystem operation on the cache entry failed (permissions,
+    /// full disk, …) — distinct from a network failure so the hint is accurate.
+    Io { url: String, detail: String },
 }
 
 impl std::fmt::Display for TemplateSourceError {
@@ -282,6 +285,11 @@ impl std::fmt::Display for TemplateSourceError {
                 "cv_template_path '{value}' is neither a readable local directory \
                  nor a git URL"
             ),
+            TemplateSourceError::Io { url, detail } => write!(
+                formatter,
+                "could not prepare the local cache for {url}: {detail} — \
+                 check directory permissions and available disk space"
+            ),
         }
     }
 }
@@ -297,11 +305,18 @@ pub fn classify_git_stderr(stderr: &str, url: &str, git_ref: Option<&str>) -> Te
             mode: AuthMode::inferred_from_url(url),
         };
     }
-    if is_bad_ref(stderr) {
-        return TemplateSourceError::BadRef {
-            url: url.to_string(),
-            git_ref: git_ref.unwrap_or_default().to_string(),
-        };
+    // A bad-ref stderr only classifies as `BadRef` when a ref was actually
+    // pinned. A no-ref clone failing with a ref-ish message (e.g. a missing repo
+    // or access problem) is a bad-URL / network class, not a ref problem — so it
+    // falls through to `NetworkOffline` rather than emitting a confusing "ref ''"
+    // message (LOW 3).
+    if let Some(reference) = git_ref {
+        if is_bad_ref(stderr) {
+            return TemplateSourceError::BadRef {
+                url: url.to_string(),
+                git_ref: reference.to_string(),
+            };
+        }
     }
     // Network/offline is the residual class: an unreachable host or an
     // otherwise-unrecognised transport failure means the remote is unusable.
@@ -471,15 +486,20 @@ impl GitHubRepository {
     }
 
     /// Update an existing cache entry (remote reachable): fetch, then re-checkout
-    /// the pinned ref. A fetch or checkout failure is classified from its captured
+    /// the pinned ref. The fetch is auth-routed the same way as the clone/probe —
+    /// an HTTPS+token cache refresh would otherwise fail auth (the SSH agent path
+    /// adds no flags). A fetch or checkout failure is classified from its captured
     /// stderr — never a silent fallback (TS-03/AC3).
     fn fetch_existing_entry(
         &self,
         runner: &dyn CommandRunner,
         entry: &str,
     ) -> Result<String, TemplateSourceError> {
+        let flags = auth_invocation_flags(self.auth, &self.url);
+        let mut args: Vec<&str> = flags.iter().map(String::as_str).collect();
+        args.extend_from_slice(&["fetch", "--prune", "--tags"]);
         let fetch = runner
-            .run_capturing("git", &["fetch", "--prune", "--tags"], Some(entry))
+            .run_capturing("git", &args, Some(entry))
             .map_err(|_| TemplateSourceError::NetworkOffline {
                 url: self.url.clone(),
             })?;
@@ -522,7 +542,11 @@ impl GitHubRepository {
         })?;
 
         if !outcome.success {
-            return Err(classify_git_stderr(&outcome.stderr, &self.url, None));
+            return Err(classify_git_stderr(
+                &outcome.stderr,
+                &self.url,
+                self.git_ref.as_deref(),
+            ));
         }
 
         if let Some(git_ref) = &self.git_ref {
@@ -534,16 +558,18 @@ impl GitHubRepository {
 
     /// Ensure the cache entry's parent exists and no stale clone occupies the
     /// destination, so a fresh `git clone` into it always succeeds. A filesystem
-    /// failure maps to `NetworkOffline` — the clone cannot proceed.
+    /// failure (permissions, full disk, …) maps to a distinct `Io` error carrying
+    /// the real io detail — never the misleading `NetworkOffline` hint (LOW 1).
     fn prepare_destination(&self, destination: &str) -> Result<(), TemplateSourceError> {
-        let offline = || TemplateSourceError::NetworkOffline {
+        let io = |error: std::io::Error| TemplateSourceError::Io {
             url: self.url.clone(),
+            detail: error.to_string(),
         };
         if Path::new(destination).exists() {
-            fs::remove_dir_all(destination).map_err(|_| offline())?;
+            fs::remove_dir_all(destination).map_err(io)?;
         }
         if let Some(parent) = Path::new(destination).parent() {
-            fs::create_dir_all(parent).map_err(|_| offline())?;
+            fs::create_dir_all(parent).map_err(io)?;
         }
         Ok(())
     }
@@ -712,6 +738,69 @@ mod tests {
             Err(err) => assert!(err.to_string().contains("not-a-dir-nor-url")),
         }
     }
+
+    // ── Direct coverage of the PRODUCTION resolver `resolve_classified` ──────
+    // (the skeleton `resolve` above is auth/cache/ref-UNAWARE). These assert the
+    // auth-flag assembly and the stderr→TemplateSourceError classification that
+    // the production git path actually exercises.
+
+    /// Token auth assembles `-c core.askpass=…` into the recorded clone argv.
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_classified_token_auth_wires_askpass_into_clone() {
+        let td = TempDir::new().unwrap();
+        let cache = td.path().to_str().unwrap().to_string();
+        let source = GitHubRepository::new("https://github.com/chess-seventh/cv.git".into(), cache)
+            .with_auth(AuthMode::Token);
+        let runner = FakeRunner::ok();
+
+        source.resolve_classified(&runner).unwrap();
+
+        let recorded = &runner.calls.borrow()[0];
+        assert!(
+            recorded.contains("-c core.askpass=") && recorded.contains("clone"),
+            "token clone must carry the askpass flag: {recorded}"
+        );
+    }
+
+    /// An auth-failure stderr from the clone classifies as `Auth`.
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_classified_auth_failure_stderr_maps_to_auth_error() {
+        let td = TempDir::new().unwrap();
+        let cache = td.path().to_str().unwrap().to_string();
+        let source = GitHubRepository::new("https://github.com/chess-seventh/cv.git".into(), cache)
+            .with_auth(AuthMode::Token);
+        let runner = FakeRunner::failing_with_stderr(
+            "remote: Invalid username or password.\nfatal: Authentication failed",
+        );
+
+        let err = source.resolve_classified(&runner).unwrap_err();
+        assert!(
+            matches!(err, TemplateSourceError::Auth { .. }),
+            "auth-failure stderr must classify as Auth, got: {err:?}"
+        );
+    }
+
+    /// A bad-ref stderr from the clone, WITH a pinned ref, classifies as `BadRef`
+    /// (no silent fallback). Would regress to `NetworkOffline` if the clone-failure
+    /// path passed `None` instead of the pinned ref.
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_classified_bad_ref_stderr_with_pinned_ref_maps_to_bad_ref() {
+        let td = TempDir::new().unwrap();
+        let cache = td.path().to_str().unwrap().to_string();
+        let source = GitHubRepository::new("https://github.com/chess-seventh/cv.git".into(), cache)
+            .with_ref("does-not-exist");
+        let runner =
+            FakeRunner::failing_with_stderr("fatal: couldn't find remote ref does-not-exist");
+
+        let err = source.resolve_classified(&runner).unwrap_err();
+        assert!(
+            matches!(err, TemplateSourceError::BadRef { .. }),
+            "bad-ref stderr with a pinned ref must classify as BadRef, got: {err:?}"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -773,24 +862,30 @@ mod distill_specs {
     }
 
     /// @us-02 @property
-    /// TS-02/AC2 (strengthened): secret-absence invariant. For ANY GITHUB_TOKEN
-    /// value and ANY https remote, the returned token-auth flags route through
-    /// `core.askpass` yet never embed the secret — the flags are computed
-    /// independently of the token, which stays in the environment and reaches
-    /// git only via the askpass indirection.
+    /// TS-02/AC2 (falsifiable): for ANY https remote where token auth applies, the
+    /// returned flags are non-empty AND contain `core.askpass=<fixed helper>`,
+    /// where the helper name is the fixed [`ASKPASS_HELPER`] constant, NOT derived
+    /// from the url input. This turns RED if `auth_invocation_flags` returned an
+    /// empty vec (no askpass wiring) or embedded an input-derived value in place of
+    /// the constant indirection.
     #[test]
-    fn ts02_ac2_secret_value_never_embedded_in_flags() {
+    fn ts02_ac2_token_flags_route_through_fixed_askpass_helper() {
         use proptest::prelude::*;
-        proptest!(|(token in "ghp_[A-Za-z0-9]{20,40}", name in "[a-z]{3,10}")| {
-            let url = format!("https://github.com/chess-seventh/{name}.git");
+        proptest!(|(host in "[a-z]{3,10}", tld in "[a-z]{2,4}", name in "[a-z]{3,10}")| {
+            let url = format!("https://{host}.{tld}/team/{name}.git");
             let flags = auth_invocation_flags(AuthMode::Token, &url);
             prop_assert!(
-                flags.iter().any(|f| f.contains("core.askpass")),
-                "token auth must route through core.askpass"
+                !flags.is_empty(),
+                "token auth must wire at least the askpass flag — never an empty vec"
+            );
+            let expected = format!("core.askpass={ASKPASS_HELPER}");
+            prop_assert!(
+                flags.iter().any(|f| f == &expected),
+                "token auth must point git at the fixed askpass helper constant"
             );
             prop_assert!(
-                !flags.iter().any(|f| f.contains(&token)),
-                "the generated token value must never appear in the returned flags"
+                !flags.iter().any(|f| f.contains(host.as_str()) || f.contains(name.as_str())),
+                "the helper name must be input-independent — no url fragment in the flags"
             );
         });
     }
@@ -861,17 +956,132 @@ mod distill_specs {
         assert_eq!(cache.decide(false, false), CacheAction::Abort); // AC2: hard abort
     }
 
-    /// @us-04 @property @edge
-    /// A repository and ref map to one deterministic cache entry (same input →
-    /// same key).
+    // ── TS-04 — cache executor arms (resolve_cached), not just decide() ──────
+
+    /// @us-04 @in-memory
+    /// TS-04/AC1: entry present + remote unreachable → ReuseStale → the existing
+    /// cache entry path is returned offline (no clone, no fetch).
     #[test]
-    fn ts04_cache_key_is_deterministic() {
+    #[serial_test::serial]
+    fn ts04_reuse_stale_arm_returns_existing_entry_offline() {
+        let td = TempDir::new().unwrap();
+        let cache_dir = td.path().to_str().unwrap().to_string();
+        let url = "https://github.com/chess-seventh/cv.git";
+        let cache = TemplateCache::new(cache_dir.clone());
+        let entry = cache.entry_path(url, None);
+        fs::create_dir_all(&entry).unwrap();
+        let source = GitHubRepository::new(url.into(), cache_dir);
+        let runner = FakeRunner::failing(); // ls-remote probe fails → unreachable
+
+        let resolved = source.resolve_cached(&runner, &cache).unwrap();
+        assert_eq!(
+            resolved, entry,
+            "ReuseStale must return the cached entry path"
+        );
+    }
+
+    /// @us-04 @error
+    /// TS-04/AC2: no entry + remote unreachable → Abort → `NoCache` (fail fast,
+    /// never a partial CV).
+    #[test]
+    #[serial_test::serial]
+    fn ts04_abort_arm_no_entry_offline_errors_nocache() {
+        let td = TempDir::new().unwrap();
+        let cache_dir = td.path().to_str().unwrap().to_string();
+        let url = "https://github.com/chess-seventh/cv.git";
+        let cache = TemplateCache::new(cache_dir.clone());
+        let source = GitHubRepository::new(url.into(), cache_dir);
+        let runner = FakeRunner::failing(); // ls-remote probe fails → unreachable
+
+        let err = source.resolve_cached(&runner, &cache).unwrap_err();
+        assert!(
+            matches!(err, TemplateSourceError::NoCache { .. }),
+            "Abort must classify as NoCache, got: {err:?}"
+        );
+    }
+
+    /// @us-04 @in-memory
+    /// TS-04/AC3: entry present + remote reachable → FetchCheckout → a `fetch
+    /// --prune --tags` is recorded against the entry (the perf lever, not a fresh
+    /// clone).
+    #[test]
+    #[serial_test::serial]
+    fn ts04_fetch_checkout_arm_records_fetch() {
+        let td = TempDir::new().unwrap();
+        let cache_dir = td.path().to_str().unwrap().to_string();
+        let url = "https://github.com/chess-seventh/cv.git";
+        let cache = TemplateCache::new(cache_dir.clone());
+        let entry = cache.entry_path(url, None);
+        fs::create_dir_all(&entry).unwrap();
+        let source = GitHubRepository::new(url.into(), cache_dir);
+        let runner = FakeRunner::ok(); // ls-remote probe + fetch succeed
+
+        source.resolve_cached(&runner, &cache).unwrap();
+        assert!(
+            runner
+                .calls
+                .borrow()
+                .iter()
+                .any(|c| c.contains("fetch --prune --tags")),
+            "FetchCheckout must record a fetch against the cache entry"
+        );
+    }
+
+    /// @us-04 @property
+    /// BLOCKER: on the FetchCheckout path the fetch is auth-routed exactly like the
+    /// clone/probe — a Token-auth refresh of an HTTPS cache entry MUST carry the
+    /// `core.askpass` flag, otherwise the refresh fails auth and the cache never
+    /// updates. This test is RED if the fetch invocation drops the auth flags.
+    #[test]
+    #[serial_test::serial]
+    fn ts04_fetch_path_is_auth_routed_with_askpass() {
+        let td = TempDir::new().unwrap();
+        let cache_dir = td.path().to_str().unwrap().to_string();
+        let url = "https://github.com/chess-seventh/cv.git";
+        let cache = TemplateCache::new(cache_dir.clone());
+        let entry = cache.entry_path(url, None);
+        fs::create_dir_all(&entry).unwrap();
+        let source = GitHubRepository::new(url.into(), cache_dir).with_auth(AuthMode::Token);
+        let runner = FakeRunner::ok();
+
+        source.resolve_cached(&runner, &cache).unwrap();
+
+        let calls = runner.calls.borrow();
+        let fetch_call = calls
+            .iter()
+            .find(|c| c.contains("fetch --prune --tags"))
+            .expect("FetchCheckout must record a fetch");
+        assert!(
+            fetch_call.contains("-c core.askpass="),
+            "the token fetch must carry the askpass auth flag: {fetch_call}"
+        );
+    }
+
+    /// @us-04 @property @edge
+    /// The cache key is deterministic (same input → same key) AND injective enough
+    /// to keep distinct repos and the pinned-vs-default slots apart: distinct repos
+    /// map to distinct keys, and a non-default pinned ref addresses a different
+    /// slot than the shared default-branch slot.
+    #[test]
+    fn ts04_cache_key_is_deterministic_and_injective() {
         use proptest::prelude::*;
         let cache = TemplateCache::new("/unused/cache".into());
-        proptest!(|(url in "[a-z]{3,12}",
-                    git_ref in proptest::option::of("[a-z0-9]{1,8}"))| {
-            let r = git_ref.as_deref();
-            prop_assert_eq!(cache.cache_key(&url, r), cache.cache_key(&url, r));
+        proptest!(|(name_a in "[a-z]{3,12}",
+                    name_b in "[a-z]{3,12}",
+                    git_ref in "[a-z0-9]{1,8}")| {
+            prop_assume!(name_a != name_b);
+            prop_assume!(git_ref != DEFAULT_REF_SLOT);
+            let url_a = format!("https://github.com/team/{name_a}.git");
+            let url_b = format!("https://github.com/team/{name_b}.git");
+            // determinism: same input → same key
+            prop_assert_eq!(cache.cache_key(&url_a, None), cache.cache_key(&url_a, None));
+            // injectivity: distinct repos must not collide on one cache slot
+            prop_assert_ne!(cache.cache_key(&url_a, None), cache.cache_key(&url_b, None));
+            // a pinned ref addresses a different slot than the default-branch slot
+            prop_assert_ne!(
+                cache.cache_key(&url_a, Some(git_ref.as_str())),
+                cache.cache_key(&url_a, None)
+            );
         });
     }
 

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -560,29 +560,36 @@ impl GitHubRepository {
         destination: &str,
         git_ref: &str,
     ) -> Result<(), TemplateSourceError> {
-        let checkout = self.run_in_clone(runner, &["checkout", git_ref], destination, git_ref)?;
-        if !checkout.success {
-            return Err(classify_git_stderr(
-                &checkout.stderr,
-                &self.url,
-                Some(git_ref),
-            ));
-        }
-
-        let resolved = self.run_in_clone(runner, &["rev-parse", "HEAD"], destination, git_ref)?;
-        if !resolved.success {
-            return Err(classify_git_stderr(
-                &resolved.stderr,
-                &self.url,
-                Some(git_ref),
-            ));
-        }
-
+        self.run_in_clone_checked(runner, &["checkout", git_ref], destination, git_ref)?;
+        let resolved =
+            self.run_in_clone_checked(runner, &["rev-parse", "HEAD"], destination, git_ref)?;
         info!(
             "✅ Pinned template to ref '{git_ref}' (resolved SHA: {})",
             resolved.stdout.trim()
         );
         Ok(())
+    }
+
+    /// Run a git subcommand inside the cloned `destination` and require success,
+    /// classifying a non-zero exit from its captured stderr (the pinned-ref
+    /// context means a failure aborts as `BadRef` — never a silent default-branch
+    /// fallback, TS-03/AC3). A captured io failure is mapped by [`run_in_clone`].
+    fn run_in_clone_checked(
+        &self,
+        runner: &dyn CommandRunner,
+        args: &[&str],
+        destination: &str,
+        git_ref: &str,
+    ) -> Result<CommandOutcome, TemplateSourceError> {
+        let outcome = self.run_in_clone(runner, args, destination, git_ref)?;
+        if !outcome.success {
+            return Err(classify_git_stderr(
+                &outcome.stderr,
+                &self.url,
+                Some(git_ref),
+            ));
+        }
+        Ok(outcome)
     }
 
     /// Run a git subcommand inside the cloned `destination`, mapping a captured

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -1106,4 +1106,183 @@ mod distill_specs {
             prop_assert!(!is_git_url(&local_path)); // local path
         });
     }
+
+    // ── Mutation hardening (Phase 5) ─────────────────────────────────────────
+    // Targeted tests that distinguish each surviving predicate from its mutant.
+    // The marker sets are finite + enumerable, so per the PBT falsifier-gate
+    // these are table-style example tests, not proptest cases.
+
+    /// @us-02 @error @mutation
+    /// Each auth-failure marker, ALONE, classifies as `Auth`. Kills the
+    /// `is_auth_failure` `||`→`&&` mutants: under `&&` a stderr carrying only ONE
+    /// of the four markers would stop classifying as auth and fall through.
+    #[test]
+    fn ts02_each_auth_marker_alone_classifies_as_auth() {
+        let url = "git@github.com:chess-seventh/cv.git";
+        for marker in [
+            "Permission denied (publickey)",
+            "Authentication failed",
+            "could not read Username",
+            "Invalid username or password",
+        ] {
+            let err = classify_git_stderr(marker, url, None);
+            assert!(
+                matches!(err, TemplateSourceError::Auth { .. }),
+                "auth marker {marker:?} alone must classify as Auth, got: {err:?}"
+            );
+        }
+    }
+
+    /// @us-03 @error @mutation
+    /// Each bad-ref marker ALONE (with a pinned ref) classifies as `BadRef`,
+    /// killing the `is_bad_ref` `||`→`&&` mutants; AND an UNRELATED stderr (still
+    /// with a pinned ref) classifies as `NetworkOffline`, killing the
+    /// `is_bad_ref -> true` mutant (which would coerce anything to `BadRef`).
+    #[test]
+    fn ts03_each_bad_ref_marker_alone_and_unrelated_stays_network() {
+        let url = "https://github.com/chess-seventh/cv.git";
+        for marker in [
+            "couldn't find remote ref",
+            "did not match any file(s) known to git",
+            "Remote branch",
+            "not found in upstream",
+        ] {
+            let err = classify_git_stderr(marker, url, Some("v9"));
+            assert!(
+                matches!(err, TemplateSourceError::BadRef { .. }),
+                "bad-ref marker {marker:?} alone must classify as BadRef, got: {err:?}"
+            );
+        }
+        let unrelated = classify_git_stderr(
+            "fatal: unable to access: Could not resolve host",
+            url,
+            Some("v9"),
+        );
+        assert!(
+            matches!(unrelated, TemplateSourceError::NetworkOffline { .. }),
+            "an unrelated stderr must stay NetworkOffline, got: {unrelated:?}"
+        );
+    }
+
+    /// @us-02 @mutation
+    /// `AuthMode::Auto` infers the transport from the URL scheme: both `git@…` and
+    /// `ssh://…` remotes infer SSH (→ NO askpass flags), anything else infers Token
+    /// (→ askpass flags present). Asserting BOTH ssh-scheme forms yield empty flags
+    /// kills the `inferred_from_url` `||`→`&&` mutant (under `&&` no url matches
+    /// both schemes → always Token → non-empty flags).
+    #[test]
+    fn ts02_auto_infers_ssh_for_both_ssh_schemes() {
+        assert!(
+            auth_invocation_flags(AuthMode::Auto, "git@github.com:chess-seventh/cv.git").is_empty(),
+            "a git@ remote infers SSH — no askpass flags"
+        );
+        assert!(
+            auth_invocation_flags(AuthMode::Auto, "ssh://git@github.com/chess-seventh/cv.git")
+                .is_empty(),
+            "an ssh:// remote infers SSH — no askpass flags"
+        );
+        assert!(
+            !auth_invocation_flags(AuthMode::Auto, "https://github.com/chess-seventh/cv.git")
+                .is_empty(),
+            "an https remote infers Token — askpass flags present"
+        );
+    }
+
+    /// @us-02 @error @mutation
+    /// The `Auth` error Display embeds the EXACT auth-mode hint name, so the
+    /// operator hint is accurate. Kills the `hint_name -> "" / "xyzzy"` mutant: a
+    /// replaced body would drop the real "auto"/"ssh"/"token" text.
+    #[test]
+    fn ts02_auth_error_display_contains_exact_mode_hint() {
+        for (mode, hint) in [
+            (AuthMode::Auto, "auto"),
+            (AuthMode::Ssh, "ssh"),
+            (AuthMode::Token, "token"),
+        ] {
+            let err = TemplateSourceError::Auth {
+                url: "https://github.com/chess-seventh/cv.git".to_string(),
+                mode,
+            };
+            let rendered = err.to_string();
+            assert!(
+                rendered.contains(&format!("auth mode: {hint}")),
+                "Auth Display must name the {hint:?} mode, got: {rendered}"
+            );
+        }
+    }
+
+    /// @us-04 @mutation
+    /// `entry_path` returns a real path UNDER the cache dir whose final component is
+    /// the sanitised `repo@ref` cache key — not an arbitrary string. Kills the
+    /// `entry_path -> "xyzzy".into()` mutant.
+    #[test]
+    fn ts04_entry_path_is_under_cache_dir_with_sanitised_key() {
+        let cache = TemplateCache::new("/var/cache/cv".into());
+        let url = "https://github.com/chess-seventh/cv.git";
+        let path = cache.entry_path(url, Some("v2.1"));
+        let key = cache.cache_key(url, Some("v2.1"));
+        assert!(
+            path.starts_with("/var/cache/cv/"),
+            "entry_path must live under the cache dir, got: {path}"
+        );
+        assert!(
+            path.ends_with(&key),
+            "entry_path must end with the sanitised cache key, got: {path}"
+        );
+    }
+
+    /// @us-02 @mutation
+    /// `resolve_classified` must actually prepare the destination — creating the
+    /// cache entry's parent directory so the clone can land. With a non-existent
+    /// nested cache dir, that directory is created as an observable side effect.
+    /// Kills the `prepare_destination -> Ok(())` mutant, which would skip the work.
+    #[test]
+    #[serial_test::serial]
+    fn ts02_resolve_classified_prepares_missing_cache_parent_dir() {
+        let td = TempDir::new().unwrap();
+        let cache_dir = format!("{}/nested/cache", td.path().display());
+        assert!(
+            !Path::new(&cache_dir).exists(),
+            "precondition: nested cache dir must be absent"
+        );
+        let source = GitHubRepository::new(
+            "https://github.com/chess-seventh/cv.git".into(),
+            cache_dir.clone(),
+        );
+        let runner = FakeRunner::ok();
+
+        source.resolve_classified(&runner).unwrap();
+
+        assert!(
+            Path::new(&cache_dir).is_dir(),
+            "prepare_destination must create the cache entry's parent dir"
+        );
+    }
+
+    /// @us-01 @us-04 @mutation
+    /// The production resolver routes a (non-dir) git URL through the cache-aware
+    /// git path — which probes the remote with `ls-remote` before deciding — NOT
+    /// through the skeleton passthrough. Kills the `resolve_template_for_config`
+    /// `delete !` mutant, which would force EVERY value (git URL included) down the
+    /// passthrough branch where no `ls-remote` probe happens.
+    #[test]
+    #[serial_test::serial]
+    fn ts04_config_resolver_routes_git_url_through_cache_probe() {
+        let td = TempDir::new().unwrap();
+        let cache_dir = td.path().to_str().unwrap().to_string();
+        let url = "https://github.com/chess-seventh/cv.git";
+        let runner = FakeRunner::ok();
+
+        resolve_template_for_config(url, &cache_dir, None, AuthMode::Token, &runner).unwrap();
+
+        assert!(
+            runner
+                .calls
+                .borrow()
+                .iter()
+                .any(|c| c.contains("ls-remote")),
+            "a git URL must go through the cache-aware path (ls-remote probe), calls: {:?}",
+            runner.calls.borrow()
+        );
+    }
 }

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -15,7 +15,7 @@
 
 use crate::command_runner::{CommandOutcome, CommandRunner};
 use crate::helpers::ensure_tools_available;
-use log::info;
+use log::{info, warn};
 use std::fs;
 use std::path::Path;
 
@@ -64,22 +64,11 @@ impl GitHubRepository {
         }
     }
 
-    /// Deterministic per-repository sub-directory of the cache dir. Cache keying
-    /// by ref and reuse-on-failure are later slices (TS-03 / TS-04); the skeleton
-    /// always clones fresh into this location.
+    /// Deterministic per-`repo@ref` sub-directory of the cache dir, shared with
+    /// [`TemplateCache::cache_key`] so a cache probe and a clone address the same
+    /// entry. An unset ref folds to the shared default-branch slot.
     fn clone_destination(&self) -> String {
-        let sanitized: String = self
-            .url
-            .chars()
-            .map(|character| {
-                if character.is_ascii_alphanumeric() {
-                    character
-                } else {
-                    '_'
-                }
-            })
-            .collect();
-        format!("{}/{sanitized}", self.cache_dir)
+        TemplateCache::new(self.cache_dir.clone()).entry_path(&self.url, self.git_ref.as_deref())
     }
 }
 
@@ -141,19 +130,48 @@ fn is_git_url(value: &str) -> bool {
         || (value.starts_with("https://") && value.ends_with(".git"))
 }
 
+/// Production resolver entry (step 04-02): resolve the configured
+/// `cv_template_path` to a local template directory, threading the optional
+/// `cv_template_ref` (TS-03), `cv_template_auth` (TS-02) and the cache dir
+/// (TS-04) for git sources. A local directory is an unchanged passthrough
+/// (TS-01/AC2); a git URL resolves through the cache executor (probe → decide →
+/// clone / fetch / reuse-stale / abort). Anything else is rejected by
+/// [`detect_template_source`], naming the offending value (TS-01/AC3).
+pub fn resolve_template_for_config(
+    value: &str,
+    cache_dir: &str,
+    git_ref: Option<&str>,
+    auth: AuthMode,
+    runner: &dyn CommandRunner,
+) -> Result<String, Box<dyn std::error::Error>> {
+    // Local-dir precedence matches `detect_template_source`: only a non-directory
+    // value that parses as a git URL takes the enriched (ref/auth/cache) path.
+    if !Path::new(value).is_dir() && is_git_url(value) {
+        // ADR-0004 pre-usage check: fail fast with a devenv hint if git is absent.
+        ensure_tools_available(&["git"])?;
+        let mut repository =
+            GitHubRepository::new(value.to_string(), cache_dir.to_string()).with_auth(auth);
+        if let Some(reference) = git_ref {
+            repository = repository.with_ref(reference);
+        }
+        let cache = TemplateCache::new(cache_dir.to_string());
+        return Ok(repository.resolve_cached(runner, &cache)?);
+    }
+    // Local-dir passthrough and the BadValue error stay with the classifier.
+    detect_template_source(value, cache_dir)?.resolve(runner)
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
-// DISTILL RED scaffolds — slices TS-02 (auth), TS-03 (ref pinning),
-// TS-04 (cache/offline) and TS-D1 (typed errors). ADDITIVE ONLY: the green
-// skeleton above (`LocalDirectory`, `GitHubRepository::new`/`resolve`,
-// `detect_template_source`, `is_git_url`) is untouched. Every body `panic!`s so
-// the pending specs in `mod distill_specs` classify RED (not BROKEN). DELIVER
-// replaces these bodies. Detect markers: `// SCAFFOLD: true`.
+// Auth (TS-02), ref pinning (TS-03), cache / offline (TS-04) and typed errors
+// (TS-D1) — wired into the production resolver `resolve_template_for_config`
+// above (consumed by `file_handlers::prepare_path_for_new_cv`). The skeleton
+// happy path (`LocalDirectory`, `GitHubRepository::new`/`resolve`,
+// `detect_template_source`, `is_git_url`) is unchanged.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Auth transport (TS-D3, TS-02). Inferred from the URL scheme by default;
 /// `token` reads `GITHUB_TOKEN` from the environment and feeds git via
 /// `core.askpass` — never the INI, the argv, or the cache `.git/config`.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthMode {
     Auto,
@@ -165,7 +183,6 @@ impl AuthMode {
     /// Parse the optional `[cv] cv_template_auth` value (`auto|ssh|token`). An
     /// unknown value fails fast as a typed `TemplateSourceError::BadValue`
     /// naming the offending value — never a silent default (TS-02/AC3).
-    #[allow(dead_code)]
     pub fn from_config(value: &str) -> Result<AuthMode, TemplateSourceError> {
         match value {
             "auto" => Ok(AuthMode::Auto),
@@ -178,7 +195,6 @@ impl AuthMode {
     }
 
     /// Human-facing name used in error hints (never the secret token value).
-    #[allow(dead_code)]
     fn hint_name(self) -> &'static str {
         match self {
             AuthMode::Auto => "auto",
@@ -213,7 +229,6 @@ const ASKPASS_HELPER: &str = "git-askpass-from-env";
 ///   (SPIKE-proven against the real private repo).
 /// * `Token` routes through a `core.askpass` helper that reads `GITHUB_TOKEN`
 ///   from the environment; the secret VALUE never appears in the returned flags.
-#[allow(dead_code)]
 pub fn auth_invocation_flags(auth: AuthMode, url: &str) -> Vec<String> {
     match auth {
         AuthMode::Auto => auth_invocation_flags(AuthMode::inferred_from_url(url), url),
@@ -224,7 +239,6 @@ pub fn auth_invocation_flags(auth: AuthMode, url: &str) -> Vec<String> {
 
 /// Typed failure classes (TS-D1). Distinct variants so the resolver emits a
 /// distinct actionable hint per failure by `match`, never by string-compare.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum TemplateSourceError {
     /// Auth rejected (e.g. SSH publickey / bad token) — TS-02/AC3.
@@ -276,7 +290,6 @@ impl std::error::Error for TemplateSourceError {}
 
 /// Pure (UC-1): map git's stderr to a typed failure class, so auth vs
 /// network/offline vs bad-ref each get a distinct hint (TS-02/AC3, TS-03/AC3).
-#[allow(dead_code)]
 pub fn classify_git_stderr(stderr: &str, url: &str, git_ref: Option<&str>) -> TemplateSourceError {
     if is_auth_failure(stderr) {
         return TemplateSourceError::Auth {
@@ -318,7 +331,6 @@ fn is_bad_ref(stderr: &str) -> bool {
 
 /// Pure reuse-vs-fetch-vs-abort decision (TS-D2, TS-04). A total function over
 /// (cache-entry-present, remote-reachable) — never panics once implemented.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheAction {
     /// No entry yet — full clone.
@@ -333,13 +345,11 @@ pub enum CacheAction {
 
 /// Owns cache-key derivation and the pure cache decision (TS-D2). Only the
 /// executor writes, and its write universe is bounded to the cache dir.
-#[allow(dead_code)]
 pub struct TemplateCache {
     cache_dir: String,
 }
 
 impl TemplateCache {
-    #[allow(dead_code)]
     pub fn new(cache_dir: String) -> Self {
         Self { cache_dir }
     }
@@ -349,7 +359,6 @@ impl TemplateCache {
     /// sanitised (non-alphanumerics fold to `_`) and joined with `@`; an unset
     /// ref folds to one shared default-branch slot, so every default-branch
     /// resolve of a repository addresses the same entry.
-    #[allow(dead_code)]
     pub fn cache_key(&self, url: &str, git_ref: Option<&str>) -> String {
         let repository = sanitize_key_component(url);
         let reference = git_ref
@@ -358,11 +367,17 @@ impl TemplateCache {
         format!("{repository}@{reference}")
     }
 
+    /// Absolute cache entry directory for `repo@ref`: the cache dir joined with
+    /// the deterministic [`cache_key`](Self::cache_key). A cache probe and a clone
+    /// address the same entry through this single derivation.
+    pub fn entry_path(&self, url: &str, git_ref: Option<&str>) -> String {
+        format!("{}/{}", self.cache_dir, self.cache_key(url, git_ref))
+    }
+
     /// Pure decision over (entry-exists, remote-reachable) — the TS-04 matrix.
     /// Total: every point of the 2×2 boolean universe maps to exactly one
     /// [`CacheAction`], so the decision is DATA (a value to act on later), never
     /// an in-line side effect.
-    #[allow(dead_code)]
     pub fn decide(&self, entry_exists: bool, remote_reachable: bool) -> CacheAction {
         match (entry_exists, remote_reachable) {
             (false, true) => CacheAction::Clone,
@@ -396,7 +411,6 @@ fn sanitize_key_component(value: &str) -> String {
 impl GitHubRepository {
     /// Pin the template to a branch/tag/SHA (TS-03). Additive builder; the
     /// skeleton's default-branch `new`/`resolve` are unchanged.
-    #[allow(dead_code)]
     pub fn with_ref(mut self, git_ref: &str) -> Self {
         self.git_ref = Some(git_ref.to_string());
         self
@@ -404,31 +418,98 @@ impl GitHubRepository {
 
     /// Select the auth transport (TS-02). Additive builder; the skeleton's
     /// default-branch `new`/`resolve` are unchanged.
-    #[allow(dead_code)]
     pub fn with_auth(mut self, auth: AuthMode) -> Self {
         self.auth = auth;
         self
     }
 
-    /// Resolve with auth-routed clone and typed failure classification
-    /// (TS-02). Distinct from the skeleton's `resolve`, which stays the green
-    /// default-branch happy path (TS-01/AC1).
+    /// Cache-aware resolution (TS-04, step 04-02 executor): probe remote
+    /// reachability, decide via [`TemplateCache::decide`], then perform the chosen
+    /// [`CacheAction`] against the cache entry:
     ///
-    /// Cache reuse (TS-04) wiring lands in a later slice. Here it prepends the
-    /// auth flags to the git invocation through `CommandRunner` and classifies a
-    /// clone failure from its captured stderr. The SSH path adds no askpass flag
-    /// — the agent is inherited. When a ref is pinned (TS-03) the cloned repo is
-    /// explicitly checked out at that ref and its resolved SHA logged; an
-    /// unresolvable ref aborts via `BadRef` with NO silent default-branch
-    /// fallback. An unset ref preserves the skeleton's default-branch resolve.
-    #[allow(dead_code)]
+    /// * `Clone`         — no entry yet: a fresh auth-routed clone + ref checkout.
+    /// * `FetchCheckout` — entry present and remote reachable: fetch then
+    ///   re-checkout the pinned ref (the perf lever).
+    /// * `ReuseStale`    — remote unreachable but a usable entry exists: reuse it
+    ///   offline with a warning.
+    /// * `Abort`         — remote unreachable and no entry: fail fast as `NoCache`
+    ///   (no partial CV).
+    pub fn resolve_cached(
+        &self,
+        runner: &dyn CommandRunner,
+        cache: &TemplateCache,
+    ) -> Result<String, TemplateSourceError> {
+        let entry = self.clone_destination();
+        let entry_exists = Path::new(&entry).is_dir();
+        let remote_reachable = self.remote_reachable(runner);
+
+        match cache.decide(entry_exists, remote_reachable) {
+            CacheAction::Clone => self.resolve_classified(runner),
+            CacheAction::FetchCheckout => self.fetch_existing_entry(runner, &entry),
+            CacheAction::ReuseStale => {
+                warn!("⚠️  Offline — reusing the cached template at {entry} (it may be stale)");
+                Ok(entry)
+            }
+            CacheAction::Abort => Err(TemplateSourceError::NoCache {
+                repo_ref: cache.cache_key(&self.url, self.git_ref.as_deref()),
+            }),
+        }
+    }
+
+    /// Probe whether the remote is reachable under the configured auth by listing
+    /// its refs. A captured io failure or a non-zero exit reads as unreachable, so
+    /// the cache decision falls back to reuse-or-abort (TS-04).
+    fn remote_reachable(&self, runner: &dyn CommandRunner) -> bool {
+        let flags = auth_invocation_flags(self.auth, &self.url);
+        let mut args: Vec<&str> = flags.iter().map(String::as_str).collect();
+        args.push("ls-remote");
+        args.push(&self.url);
+        runner
+            .run_capturing("git", &args, None)
+            .map(|outcome| outcome.success)
+            .unwrap_or(false)
+    }
+
+    /// Update an existing cache entry (remote reachable): fetch, then re-checkout
+    /// the pinned ref. A fetch or checkout failure is classified from its captured
+    /// stderr — never a silent fallback (TS-03/AC3).
+    fn fetch_existing_entry(
+        &self,
+        runner: &dyn CommandRunner,
+        entry: &str,
+    ) -> Result<String, TemplateSourceError> {
+        let fetch = runner
+            .run_capturing("git", &["fetch", "--prune", "--tags"], Some(entry))
+            .map_err(|_| TemplateSourceError::NetworkOffline {
+                url: self.url.clone(),
+            })?;
+        if !fetch.success {
+            return Err(classify_git_stderr(
+                &fetch.stderr,
+                &self.url,
+                self.git_ref.as_deref(),
+            ));
+        }
+        if let Some(git_ref) = &self.git_ref {
+            self.checkout_pinned_ref(runner, entry, git_ref)?;
+        }
+        Ok(entry.to_string())
+    }
+
+    /// Resolve with an auth-routed clone and typed failure classification (TS-02 /
+    /// TS-03). Prepares the destination (fresh parent dir, no stale clone), clones
+    /// with the auth flags through `CommandRunner`, classifies a failure from
+    /// captured stderr, then — when a ref is pinned — checks it out and logs the
+    /// resolved SHA, aborting via `BadRef` with NO silent default-branch fallback.
+    /// The SSH path adds no askpass flag — the agent is inherited.
     pub fn resolve_classified(
         &self,
         runner: &dyn CommandRunner,
     ) -> Result<String, TemplateSourceError> {
-        let flags = auth_invocation_flags(self.auth, &self.url);
         let destination = self.clone_destination();
+        self.prepare_destination(&destination)?;
 
+        let flags = auth_invocation_flags(self.auth, &self.url);
         let mut args: Vec<&str> = flags.iter().map(String::as_str).collect();
         args.push("clone");
         args.push(&self.url);
@@ -449,6 +530,22 @@ impl GitHubRepository {
         }
 
         Ok(destination)
+    }
+
+    /// Ensure the cache entry's parent exists and no stale clone occupies the
+    /// destination, so a fresh `git clone` into it always succeeds. A filesystem
+    /// failure maps to `NetworkOffline` — the clone cannot proceed.
+    fn prepare_destination(&self, destination: &str) -> Result<(), TemplateSourceError> {
+        let offline = || TemplateSourceError::NetworkOffline {
+            url: self.url.clone(),
+        };
+        if Path::new(destination).exists() {
+            fs::remove_dir_all(destination).map_err(|_| offline())?;
+        }
+        if let Some(parent) = Path::new(destination).parent() {
+            fs::create_dir_all(parent).map_err(|_| offline())?;
+        }
+        Ok(())
     }
 
     /// Explicitly check out `git_ref` in the freshly cloned `destination`, then

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -1,0 +1,239 @@
+//! Template sourcing (D7) — resolve the CV template directory from either a
+//! local path or a git URL.
+//!
+//! The OO shape locked in DISCUSS: a [`TemplateSource`] trait with two concrete
+//! implementors — [`LocalDirectory`] (passthrough of an existing local path,
+//! today's behaviour and the backward-compat guarantee) and
+//! [`GitHubRepository`] (clones a git URL into the cache dir). The git mechanism
+//! is a shell-out routed through the existing [`CommandRunner`] port (ADR-0002),
+//! so no git Rust crate is needed and the clone is testable with `FakeRunner`.
+//!
+//! Walking-skeleton scope (slice 01 / TS-01): only the public-clone happy path
+//! and the local-dir passthrough. Private auth (TS-02), ref pinning (TS-03) and
+//! cache reuse / offline fallback (TS-04) are later slices and intentionally
+//! absent here.
+
+use crate::command_runner::CommandRunner;
+use crate::helpers::ensure_tools_available;
+use log::info;
+use std::fs;
+use std::path::Path;
+
+/// A source of the CV template that resolves to a local directory which the
+/// existing `copy_dir` flow consumes unchanged (D5).
+pub trait TemplateSource {
+    /// Resolve this source to a local template directory path.
+    fn resolve(&self, runner: &dyn CommandRunner) -> Result<String, Box<dyn std::error::Error>>;
+}
+
+/// Passthrough source: the configured value already points at a local template
+/// directory. Resolving returns the path unchanged — this is the pre-feature
+/// behaviour and the backward-compatibility guarantee (TS-01/AC2).
+pub struct LocalDirectory {
+    path: String,
+}
+
+impl LocalDirectory {
+    pub fn new(path: String) -> Self {
+        Self { path }
+    }
+}
+
+impl TemplateSource for LocalDirectory {
+    fn resolve(&self, _runner: &dyn CommandRunner) -> Result<String, Box<dyn std::error::Error>> {
+        Ok(self.path.clone())
+    }
+}
+
+/// Git-backed source: clones the repository's default branch into the cache
+/// directory and resolves to that local clone (TS-01/AC1).
+pub struct GitHubRepository {
+    url: String,
+    cache_dir: String,
+}
+
+impl GitHubRepository {
+    pub fn new(url: String, cache_dir: String) -> Self {
+        Self { url, cache_dir }
+    }
+
+    /// Deterministic per-repository sub-directory of the cache dir. Cache keying
+    /// by ref and reuse-on-failure are later slices (TS-03 / TS-04); the skeleton
+    /// always clones fresh into this location.
+    fn clone_destination(&self) -> String {
+        let sanitized: String = self
+            .url
+            .chars()
+            .map(|character| {
+                if character.is_ascii_alphanumeric() {
+                    character
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        format!("{}/{sanitized}", self.cache_dir)
+    }
+}
+
+impl TemplateSource for GitHubRepository {
+    fn resolve(&self, runner: &dyn CommandRunner) -> Result<String, Box<dyn std::error::Error>> {
+        // ADR-0004 pre-usage check: fail fast with a devenv hint if git is absent.
+        ensure_tools_available(&["git"])?;
+
+        let destination = self.clone_destination();
+
+        // Skeleton: no cache reuse yet (TS-04) — always clone fresh.
+        if Path::new(&destination).exists() {
+            fs::remove_dir_all(&destination)?;
+        }
+        if let Some(parent) = Path::new(&destination).parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        info!("✅ Cloning template from {} (default branch)", self.url);
+        if !runner.status("git", &["clone", &self.url, &destination], None)? {
+            return Err(format!("git clone failed for {}", self.url).into());
+        }
+
+        info!("✅ Template cloned to {destination}");
+        Ok(destination)
+    }
+}
+
+/// Auto-detect (D1) which [`TemplateSource`] to use from the configured
+/// `cv_template_path` value: an existing readable directory → [`LocalDirectory`];
+/// a git URL → [`GitHubRepository`]. Anything else is rejected with a message
+/// naming the offending value and the accepted forms (TS-01/AC3).
+pub fn detect_template_source(
+    value: &str,
+    cache_dir: &str,
+) -> Result<Box<dyn TemplateSource>, Box<dyn std::error::Error>> {
+    if Path::new(value).is_dir() {
+        return Ok(Box::new(LocalDirectory::new(value.to_string())));
+    }
+    if is_git_url(value) {
+        return Ok(Box::new(GitHubRepository::new(
+            value.to_string(),
+            cache_dir.to_string(),
+        )));
+    }
+    Err(format!(
+        "cv_template_path '{value}' is neither a readable local directory nor a git URL \
+         (expected an existing directory, a 'git@…' SSH URL, or an 'https://….git' URL)"
+    )
+    .into())
+}
+
+/// True when `value` looks like a clonable git URL. Besides the two GitHub forms
+/// named in D1 (`git@…`, `https://….git`), a `file://…` local remote is also
+/// recognised — it is a genuine clonable git URL used for local/offline remotes.
+fn is_git_url(value: &str) -> bool {
+    value.starts_with("git@")
+        || value.starts_with("file://")
+        || (value.starts_with("https://") && value.ends_with(".git"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command_runner::testing::FakeRunner;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_local_directory_resolves_to_passthrough_path() {
+        let source = LocalDirectory::new("/some/local/template".to_string());
+        let runner = FakeRunner::ok();
+        assert_eq!(source.resolve(&runner).unwrap(), "/some/local/template");
+    }
+
+    #[test]
+    fn test_local_directory_does_not_invoke_runner() {
+        let source = LocalDirectory::new("/some/local/template".to_string());
+        let runner = FakeRunner::ok();
+        source.resolve(&runner).unwrap();
+        assert!(runner.calls.borrow().is_empty());
+    }
+
+    // Serialized: `resolve` reads the global PATH (ADR-0004 git check), which the
+    // PATH-mutating test in `helpers` temporarily clobbers.
+    #[test]
+    #[serial_test::serial]
+    fn test_github_repository_clones_via_runner() {
+        let td = TempDir::new().unwrap();
+        let cache = td.path().to_str().unwrap().to_string();
+        let source =
+            GitHubRepository::new("https://github.com/chess-seventh/cv.git".to_string(), cache);
+        let runner = FakeRunner::ok();
+
+        let resolved = source.resolve(&runner).unwrap();
+
+        let recorded = &runner.calls.borrow()[0];
+        assert!(recorded.starts_with("git clone https://github.com/chess-seventh/cv.git "));
+        assert!(recorded.ends_with(&resolved));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_github_repository_errors_when_clone_fails() {
+        let td = TempDir::new().unwrap();
+        let cache = td.path().to_str().unwrap().to_string();
+        let source =
+            GitHubRepository::new("https://github.com/chess-seventh/cv.git".to_string(), cache);
+        let runner = FakeRunner::failing();
+        assert!(source.resolve(&runner).is_err());
+    }
+
+    #[test]
+    fn test_detect_existing_dir_is_local() {
+        let td = TempDir::new().unwrap();
+        let dir = td.path().to_str().unwrap();
+        let runner = FakeRunner::ok();
+        // A local dir resolves to itself and does not shell out.
+        let resolved = detect_template_source(dir, "/unused/cache")
+            .unwrap()
+            .resolve(&runner)
+            .unwrap();
+        assert_eq!(resolved, dir);
+        assert!(runner.calls.borrow().is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_detect_ssh_url_is_github() {
+        let td = TempDir::new().unwrap();
+        let cache = td.path().to_str().unwrap().to_string();
+        let runner = FakeRunner::ok();
+        detect_template_source("git@github.com:chess-seventh/cv.git", &cache)
+            .unwrap()
+            .resolve(&runner)
+            .unwrap();
+        assert!(
+            runner.calls.borrow()[0].starts_with("git clone git@github.com:chess-seventh/cv.git")
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_detect_https_git_url_is_github() {
+        let td = TempDir::new().unwrap();
+        let cache = td.path().to_str().unwrap().to_string();
+        let runner = FakeRunner::ok();
+        detect_template_source("https://github.com/chess-seventh/cv.git", &cache)
+            .unwrap()
+            .resolve(&runner)
+            .unwrap();
+        assert!(
+            runner.calls.borrow()[0]
+                .starts_with("git clone https://github.com/chess-seventh/cv.git")
+        );
+    }
+
+    #[test]
+    fn test_detect_unrecognised_value_errors_naming_value() {
+        match detect_template_source("not-a-dir-nor-url", "/unused/cache") {
+            Ok(_) => panic!("unrecognised value should not resolve to a source"),
+            Err(err) => assert!(err.to_string().contains("not-a-dir-nor-url")),
+        }
+    }
+}

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -345,19 +345,52 @@ impl TemplateCache {
     }
 
     /// Deterministic sanitised cache key for `repo@ref`. Pure — same input maps
-    /// to the same key (PBT in `mod distill_specs`).
-    // SCAFFOLD: true
+    /// to the same key (PBT in `mod distill_specs`). The url and ref are each
+    /// sanitised (non-alphanumerics fold to `_`) and joined with `@`; an unset
+    /// ref folds to one shared default-branch slot, so every default-branch
+    /// resolve of a repository addresses the same entry.
     #[allow(dead_code)]
-    pub fn cache_key(&self, _url: &str, _git_ref: Option<&str>) -> String {
-        panic!("not yet implemented — RED scaffold")
+    pub fn cache_key(&self, url: &str, git_ref: Option<&str>) -> String {
+        let repository = sanitize_key_component(url);
+        let reference = git_ref
+            .map(sanitize_key_component)
+            .unwrap_or_else(|| DEFAULT_REF_SLOT.to_string());
+        format!("{repository}@{reference}")
     }
 
     /// Pure decision over (entry-exists, remote-reachable) — the TS-04 matrix.
-    // SCAFFOLD: true
+    /// Total: every point of the 2×2 boolean universe maps to exactly one
+    /// [`CacheAction`], so the decision is DATA (a value to act on later), never
+    /// an in-line side effect.
     #[allow(dead_code)]
-    pub fn decide(&self, _entry_exists: bool, _remote_reachable: bool) -> CacheAction {
-        panic!("not yet implemented — RED scaffold")
+    pub fn decide(&self, entry_exists: bool, remote_reachable: bool) -> CacheAction {
+        match (entry_exists, remote_reachable) {
+            (false, true) => CacheAction::Clone,
+            (true, true) => CacheAction::FetchCheckout,
+            (true, false) => CacheAction::ReuseStale,
+            (false, false) => CacheAction::Abort,
+        }
     }
+}
+
+/// Cache slot addressed when no explicit ref is pinned: every default-branch
+/// resolve of a repository folds to this one deterministic entry (TS-04 key).
+const DEFAULT_REF_SLOT: &str = "default";
+
+/// Fold an arbitrary url/ref fragment to a filesystem-safe, deterministic slug
+/// by replacing every non-alphanumeric character with `_`. Same input always
+/// yields the same slug — this is what makes [`TemplateCache::cache_key`] pure.
+fn sanitize_key_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 impl GitHubRepository {
@@ -716,7 +749,6 @@ mod distill_specs {
     /// TS-04/AC1+AC2+AC3: the reuse-vs-fetch-vs-abort decision is total over
     /// (cache-entry-present, remote-reachable).
     #[test]
-    #[ignore = "pending DELIVER — TS-04"]
     fn ts04_cache_action_matrix() {
         let cache = TemplateCache::new("/unused/cache".into());
         assert_eq!(cache.decide(false, true), CacheAction::Clone); // AC3: fresh clone
@@ -729,7 +761,6 @@ mod distill_specs {
     /// A repository and ref map to one deterministic cache entry (same input →
     /// same key).
     #[test]
-    #[ignore = "pending DELIVER — TS-04"]
     fn ts04_cache_key_is_deterministic() {
         use proptest::prelude::*;
         let cache = TemplateCache::new("/unused/cache".into());

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -161,6 +161,25 @@ impl AuthMode {
     pub fn from_config(_value: &str) -> Result<AuthMode, TemplateSourceError> {
         panic!("not yet implemented — RED scaffold")
     }
+
+    /// Human-facing name used in error hints (never the secret token value).
+    #[allow(dead_code)]
+    fn hint_name(self) -> &'static str {
+        match self {
+            AuthMode::Auto => "auto",
+            AuthMode::Ssh => "ssh",
+            AuthMode::Token => "token",
+        }
+    }
+
+    /// Infer the transport from the URL scheme: an `git@…`/`ssh://…` remote uses
+    /// the SSH agent, anything else authenticates with a token.
+    fn inferred_from_url(url: &str) -> AuthMode {
+        if url.starts_with("git@") || url.starts_with("ssh://") {
+            return AuthMode::Ssh;
+        }
+        AuthMode::Token
+    }
 }
 
 /// Pure (TS-02/AC2): the extra `git -c` flags needed for `auth` against `url`.
@@ -190,9 +209,35 @@ pub enum TemplateSourceError {
 }
 
 impl std::fmt::Display for TemplateSourceError {
-    // SCAFFOLD: true
-    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        panic!("not yet implemented — RED scaffold")
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TemplateSourceError::Auth { url, mode } => write!(
+                formatter,
+                "authentication rejected for {url} (auth mode: {}) — \
+                 check your SSH key or that GITHUB_TOKEN is set and authorised",
+                mode.hint_name()
+            ),
+            TemplateSourceError::NetworkOffline { url } => write!(
+                formatter,
+                "could not reach {url} — the network appears offline and \
+                 no usable cached template is available"
+            ),
+            TemplateSourceError::BadRef { url, git_ref } => write!(
+                formatter,
+                "ref '{git_ref}' does not resolve in {url} — aborting \
+                 (no silent fallback to the default branch)"
+            ),
+            TemplateSourceError::NoCache { repo_ref } => write!(
+                formatter,
+                "no cached template for '{repo_ref}' and the fetch failed — \
+                 cannot proceed offline"
+            ),
+            TemplateSourceError::BadValue { value } => write!(
+                formatter,
+                "cv_template_path '{value}' is neither a readable local directory \
+                 nor a git URL"
+            ),
+        }
     }
 }
 
@@ -200,14 +245,44 @@ impl std::error::Error for TemplateSourceError {}
 
 /// Pure (UC-1): map git's stderr to a typed failure class, so auth vs
 /// network/offline vs bad-ref each get a distinct hint (TS-02/AC3, TS-03/AC3).
-// SCAFFOLD: true
 #[allow(dead_code)]
-pub fn classify_git_stderr(
-    _stderr: &str,
-    _url: &str,
-    _git_ref: Option<&str>,
-) -> TemplateSourceError {
-    panic!("not yet implemented — RED scaffold")
+pub fn classify_git_stderr(stderr: &str, url: &str, git_ref: Option<&str>) -> TemplateSourceError {
+    if is_auth_failure(stderr) {
+        return TemplateSourceError::Auth {
+            url: url.to_string(),
+            mode: AuthMode::inferred_from_url(url),
+        };
+    }
+    if is_bad_ref(stderr) {
+        return TemplateSourceError::BadRef {
+            url: url.to_string(),
+            git_ref: git_ref.unwrap_or_default().to_string(),
+        };
+    }
+    // Network/offline is the residual class: an unreachable host or an
+    // otherwise-unrecognised transport failure means the remote is unusable.
+    TemplateSourceError::NetworkOffline {
+        url: url.to_string(),
+    }
+}
+
+/// True when git's stderr signals an authentication rejection (SSH publickey or
+/// token/credential failure) — TS-02/AC3.
+fn is_auth_failure(stderr: &str) -> bool {
+    stderr.contains("Permission denied (publickey)")
+        || stderr.contains("Authentication failed")
+        || stderr.contains("could not read Username")
+        || stderr.contains("Invalid username or password")
+}
+
+/// True when git's stderr signals an unresolvable ref/pathspec — TS-03/AC3. The
+/// resolver aborts on this; it must never silently fall back to the default
+/// branch.
+fn is_bad_ref(stderr: &str) -> bool {
+    stderr.contains("couldn't find remote ref")
+        || stderr.contains("did not match any file(s) known to git")
+        || stderr.contains("Remote branch")
+        || stderr.contains("not found in upstream")
 }
 
 /// Pure reuse-vs-fetch-vs-abort decision (TS-D2, TS-04). A total function over
@@ -451,7 +526,6 @@ mod distill_specs {
     /// TS-02/AC3: an auth-failure stderr is classified as a distinct `Auth` error
     /// (separate from a network/offline error).
     #[test]
-    #[ignore = "pending DELIVER — TS-02"]
     fn ts02_ac3_auth_failure_stderr_classified_as_auth() {
         let err = classify_git_stderr(
             "git@github.com: Permission denied (publickey).",
@@ -492,7 +566,6 @@ mod distill_specs {
     /// TS-03/AC3: an unknown ref is classified as `BadRef` — the resolver aborts,
     /// it does NOT silently fall back to the default branch.
     #[test]
-    #[ignore = "pending DELIVER — TS-03"]
     fn ts03_ac3_bad_ref_classified_no_silent_fallback() {
         let err = classify_git_stderr(
             "fatal: couldn't find remote ref does-not-exist",

--- a/tests/acceptance/template-source/offline-cache.feature
+++ b/tests/acceptance/template-source/offline-cache.feature
@@ -1,0 +1,46 @@
+# Feature: Generating offline from a cached template (TS-04)
+#
+# Documentation SSOT mapped to concrete Rust tests (no cucumber-rust harness).
+# See the traceability table in docs/feature/template-source/feature-delta.md
+# (Wave: DISTILL). The reuse-vs-fetch-vs-abort decision is a pure `CacheAction`
+# matrix; cache-key derivation is deterministic. All pending DELIVER (RED scaffolds).
+#
+# @in-memory: the decision is a pure function over (cache present, remote reachable);
+#   no real network is contacted in these specs.
+
+Feature: Generating offline from a cached template
+  As Francesco on a flaky connection
+  I want the last good template reused when a fetch fails
+  So that a network hiccup never blocks an application
+
+  @US-04 @error @in-memory @contract-shape:unbounded-preservation
+  Scenario: Offline, the most recent cached template is reused with a warning
+    Given a cached template exists for the requested repository and version
+    And the remote is unreachable
+    When the cache decision is made
+    Then the cached template is reused
+
+  @US-04 @error @in-memory @contract-shape:unbounded-preservation
+  Scenario: With no cache and no network the run aborts without a partial CV
+    Given no cached template exists for the requested repository and version
+    And the remote is unreachable
+    When the cache decision is made
+    Then the run aborts and no partial CV is produced
+
+  @US-04 @in-memory @contract-shape:bounded-change
+  Scenario: A successful fetch refreshes the cache for next time
+    Given a cached template exists and the remote is reachable
+    When the cache decision is made
+    Then the cache is refreshed by fetch and checkout
+
+  @US-04 @property @contract-shape:pure-function
+  Scenario: The reuse-or-fetch-or-abort decision is total over cache and network state
+    Given any combination of cache presence and remote reachability
+    When the cache decision is made
+    Then exactly one of clone, fetch-checkout, reuse, or abort is chosen
+
+  @US-04 @property @edge @contract-shape:pure-function
+  Scenario: A repository and version map to one deterministic cache entry
+    Given the same repository and version
+    When the cache key is derived
+    Then the same cache entry is always produced

--- a/tests/acceptance/template-source/pinned-version.feature
+++ b/tests/acceptance/template-source/pinned-version.feature
@@ -1,0 +1,33 @@
+# Feature: Pinning the CV template to an exact version (TS-03)
+#
+# Documentation SSOT mapped to concrete Rust tests (no cucumber-rust harness).
+# See the traceability table in docs/feature/template-source/feature-delta.md
+# (Wave: DISTILL). Maps to in-crate `distill_specs`. The unset-ref default-branch
+# behaviour is the already-GREEN skeleton path. Pinned/bad-ref are pending DELIVER.
+#
+# @in-memory: the checkout command is asserted through the FakeRunner double.
+
+Feature: Pinning the CV template to an exact version
+  As Francesco
+  I want to pin the template to a branch, tag, or commit
+  So that a given application reproducibly uses a known-good template
+
+  @US-03 @in-memory @contract-shape:bounded-change
+  Scenario: A pinned version is checked out and its resolved revision is logged
+    Given a template version is pinned to "v2.1"
+    When the template source is resolved
+    Then that exact version is checked out
+    And its resolved revision is logged
+
+  @US-03 @contract-shape:bounded-change
+  Scenario: With no version pinned the default branch is used
+    Given no template version is pinned
+    When the template source is resolved
+    Then the repository default branch is used
+
+  @US-03 @error @in-memory @contract-shape:unbounded-preservation
+  Scenario: An unknown version is refused without falling back
+    Given a template version that does not resolve in the repository
+    When the failure is classified
+    Then it is reported as an unknown-version error
+    And the default branch is not silently used instead

--- a/tests/acceptance/template-source/private-source.feature
+++ b/tests/acceptance/template-source/private-source.feature
@@ -1,0 +1,35 @@
+# Feature: Sourcing a private CV template with existing credentials (TS-02)
+#
+# Documentation SSOT mapped to concrete Rust tests (no cucumber-rust harness).
+# See the traceability table in docs/feature/template-source/feature-delta.md
+# (Wave: DISTILL). Maps to in-crate `distill_specs` (FakeRunner asserts the exact
+# git command strings) and the UC-1 `uc1_specs`. Pending DELIVER (RED scaffolds).
+#
+# @in-memory: the git invocation is asserted through the FakeRunner double; the
+#   secret-handling guarantees are asserted on the constructed command, not by
+#   contacting a real remote.
+
+Feature: Sourcing a private CV template with existing credentials
+  As Francesco, whose canonical template repo is private
+  I want it pulled with my machine's existing auth
+  So that I need no bespoke token plumbing for my real workflow
+
+  @US-02 @in-memory @contract-shape:bounded-change
+  Scenario: A private SSH source clones over its git@ URL
+    Given "cv_template_path" is a "git@" URL with the SSH transport selected
+    When the template source is resolved
+    Then the repository is cloned over its git@ URL using the agent
+    And no askpass helper is used on the SSH path
+
+  @US-02 @error @in-memory @contract-shape:unbounded-preservation
+  Scenario: A token is taken from the environment and never placed on the command line
+    Given the token transport is selected for an "https" private URL
+    When the git invocation is prepared
+    Then the credential is supplied through an askpass helper
+    And the token value never appears in the git command line
+
+  @US-02 @error @in-memory @contract-shape:unbounded-preservation
+  Scenario: An authentication failure is reported with an auth-specific hint
+    Given a private source whose credentials are rejected
+    When the failure is classified
+    Then it is reported as an authentication failure, distinct from a network error

--- a/tests/acceptance/template-source/public-source.feature
+++ b/tests/acceptance/template-source/public-source.feature
@@ -1,0 +1,45 @@
+# Feature: Sourcing the CV template from a public location (TS-01)
+#
+# Documentation SSOT mapped to concrete Rust tests (no cucumber-rust harness).
+# See the traceability table in docs/feature/template-source/feature-delta.md
+# (Wave: DISTILL). The walking skeleton is already GREEN; the other scenarios map
+# to in-crate `distill_specs` / the subprocess driving-adapter test.
+#
+# @real-io git uses a real `git clone` from a local `file://` bare-repo fixture
+#   (deterministic, no network) — the genuine git shell-out, not a mock.
+
+Feature: Sourcing the CV template from a public location
+  As Francesco, setting up on a new machine
+  I want the tool to pull the template itself from a public git URL
+  So that I never have to clone and babysit a local copy by hand
+
+  @walking_skeleton @driving_port @US-01 @real-io @contract-shape:bounded-change
+  Scenario: Francesco sources a public template by URL end to end
+    Given "cv_template_path" is a reachable public git URL
+    When Francesco generates a CV
+    Then the repository is cloned into the cache
+    And the cloned template is staged for the build, ready under the working copy
+
+  @US-01 @edge @real-io @contract-shape:unbounded-preservation
+  Scenario: An existing local directory is used exactly as before
+    Given "cv_template_path" is an existing local template directory
+    When the template source is resolved
+    Then the directory is used unchanged and nothing is cloned
+
+  @US-01 @error @driving_adapter @real-io @contract-shape:pure-function
+  Scenario: A value that is neither a directory nor a git URL is refused
+    Given "cv_template_path" is "definitely-not-a-dir-nor-a-git-url"
+    When Francesco generates a CV
+    Then the run fails fast naming the offending value and the accepted forms
+
+  @US-01 @property @contract-shape:pure-function
+  Scenario: Recognised URL forms are detected as git sources
+    Given a value in a recognised git-URL form
+    When the source type is auto-detected
+    Then it is classified as a git source
+
+  @US-01 @property @edge @contract-shape:pure-function
+  Scenario: A bare token or local path is not mistaken for a git URL
+    Given a bare word or an ordinary local path
+    When the source type is auto-detected
+    Then it is not classified as a git source

--- a/tests/template_source_scenarios.rs
+++ b/tests/template_source_scenarios.rs
@@ -1,0 +1,89 @@
+//! template-source — subprocess driving-adapter scenarios.
+//!
+//! Driving adapter: the existing `insert` CLI entry (`rusty_cv_creator insert`),
+//! spawned as a real process. Sourcing is transparent inside the command (D6),
+//! so this exercises the user's real invocation path end-to-end through the CLI.
+//!
+//! The `@real-io` git happy path (a real `git clone` from a `file://` bare-repo
+//! fixture) is covered at the `create_directory` seam by the in-crate walking
+//! skeleton (`src/file_handlers.rs::walking_skeleton_github_source_resolves_template_dir`)
+//! and the in-crate `distill_specs`, where the binary-private `TemplateSource` /
+//! `FakeRunner` symbols are reachable — they are NOT on the library facade
+//! (`lib.rs` exposes only `database`/`models`/`schema`/`tui`), so an external
+//! integration crate cannot drive the git adapter directly.
+//!
+//! Run under devenv so `git`/`just`/`tectonic` (ADR-0004 pre-usage checks) are on
+//! PATH: `devenv shell -- cargo test --test template_source_scenarios`.
+
+use std::path::Path;
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+fn binary() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_rusty_cv_creator"))
+}
+
+fn combined(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// Write a minimal, self-contained INI whose `[cv] cv_template_path` is `value`,
+/// with a real tmp destination so the run reaches template detection.
+fn config_with_template_value(dir: &Path, value: &str) -> String {
+    let dest = dir.join("dest");
+    let out = dir.join("out");
+    std::fs::create_dir_all(&dest).unwrap();
+    let cfg = dir.join("conf.ini");
+    std::fs::write(
+        &cfg,
+        format!(
+            "[cv]\ncv_template_path = \"{value}\"\ncv_file_prefix = \"TestCV\"\n\
+             [variant]\ndefault = \"senior-devops\"\n\
+             [build]\nbuilder = \"just\"\nrecipe = \"build\"\n\
+             [destination]\ncv_path = \"{dest}\"\noutput_pdf = \"{out}\"\n\
+             [db]\nengine = \"sqlite\"\ndb_file = \"x.db\"\n",
+            dest = dest.display(),
+            out = out.display(),
+        ),
+    )
+    .unwrap();
+    cfg.display().to_string()
+}
+
+/// @driving_adapter @real-io @us-01 @error @contract-shape:pure-function
+/// TS-01/AC3: a `cv_template_path` that is neither a readable directory nor a
+/// recognisable git URL fails the run fast, naming the offending value — at the
+/// real CLI entry point, not only the unit resolver. No clone, no build, no DB.
+#[test]
+fn ts01_ac3_bad_template_value_fails_fast_naming_the_value() {
+    let td = TempDir::new().unwrap();
+    let bad = "definitely-not-a-dir-nor-a-git-url";
+    let cfg = config_with_template_value(td.path(), bad);
+
+    let output = binary()
+        .args([
+            "--config-ini",
+            &cfg,
+            "insert",
+            "--job-title",
+            "SRE",
+            "--company-name",
+            "Acme",
+        ])
+        .output()
+        .expect("failed to run insert");
+
+    assert!(
+        !output.status.success(),
+        "a bad template value must not exit 0"
+    );
+    let out = combined(&output);
+    assert!(
+        out.contains(bad),
+        "the failure should name the offending value, got: {out}"
+    );
+}


### PR DESCRIPTION
## What

Adds the ability to source the CV template from **either a local directory or a
GitHub repository** (public or private, version-pinned, cached for offline use),
instead of requiring a pre-cloned local checkout. Built through the full nWave
wave chain (DISCUSS → SPIKE → DESIGN → DISTILL → DELIVER).

`[cv] cv_template_path` is auto-detected as a local path or a git URL. New
optional keys: `cv_template_ref` (branch/tag/SHA), `cv_template_auth`
(`auto|ssh|token`), `cv_template_cache`. The downstream build flow
(`copy_dir` → `just build` → per-year filing) is **unchanged** (D5).

## How

- `TemplateSource` trait + `LocalDirectory` (passthrough) / `GitHubRepository`
  adapters; git via the existing `CommandRunner` port (ADR-0002) — **no new git
  crate** (SPIKE-validated, ADR-0008).
- Typed `TemplateSourceError` + `classify_git_stderr` (distinct auth / offline /
  bad-ref / no-cache hints).
- Auth: SSH inherits the agent; HTTPS-token via `core.askpass` reading
  `GITHUB_TOKEN` from env — **secret never on argv, never in the INI** (proptest-
  enforced).
- Ref pinning with explicit checkout + resolved-SHA logging; bad ref aborts with
  **no silent fallback**.
- `TemplateCache`: pure `decide()` 2×2 matrix (Clone / FetchCheckout /
  ReuseStale / Abort) + deterministic `repo@ref` cache key; offline reuse +
  hard-abort on no-cache.

## Quality

- **156 tests pass / 0 ignored.** Mutation testing (`cargo-mutants`, per-feature
  gate): **98.1% kill rate** on the core module.
- Adversarial review caught a real auth bug (`fetch` missing auth flags, broke
  private-HTTPS cache refresh) — fixed and proven RED-without-fix.
- DES-instrumented TDD: 6 steps, all RED→GREEN→COMMIT traces verified.
- New config keys documented in `rusty-cv-config-example.ini` + README.

## Deferred (tracked in `feature-delta.md` → DELIVER Upstream Issues)

1. **Askpass helper executable** (HTTPS-token mode) — flag wiring + secret-
   absence done & tested; the helper binary + a hermetic token-clone test remain.
   SSH (the primary workflow) fully works.
2. **Dual `TemplateCache` entry-path derivation** — correct today; a scoped
   refactor to use the injected `cache.entry_path(…)` would prevent future drift.

## Docs

DISCUSS/SPIKE/DESIGN/DISTILL/DELIVER artifacts under
`docs/feature/template-source/`, ADR-0008, C4 diagrams, and the evolution record
at `docs/evolution/template-source-evolution.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)