### PR TITLE
fix(cli): require insert args and replace panics with clean errors

### DIFF
--- a/src/cli_structure.rs
+++ b/src/cli_structure.rs
@@ -37,7 +37,7 @@ pub struct UserInput {
 #[derive(Subcommand, Debug, Clone)]
 pub enum UserAction {
     #[command(about = "Insert CV", long_about = None)]
-    Insert(FilterArgs),
+    Insert(InsertArgs),
 
     #[command(about = "Update CV", long_about = None)]
     Update(FilterArgs),
@@ -47,6 +47,40 @@ pub enum UserAction {
 
     #[command(about = "List CVs", long_about = None)]
     List(FilterArgs),
+}
+
+/// Required arguments for `insert`: a CV cannot be built without a job title and
+/// a company name, so clap enforces them at the CLI boundary (non-`Option`).
+/// `quote`/`variant` stay optional. `Default` is for tests only — clap still
+/// requires the non-`Option` fields at parse time.
+#[derive(Args, Debug, Clone, Default)]
+pub struct InsertArgs {
+    #[arg(short, long)]
+    pub job_title: String,
+
+    #[arg(short, long)]
+    pub company_name: String,
+
+    #[arg(short, long)]
+    pub quote: Option<String>,
+
+    /// Which CV variant to build (senior-devops, senior-platform-engineer,
+    /// senior-sre, engineering-manager). When omitted, it is inferred from the
+    /// job title, falling back to the configured default.
+    #[arg(long)]
+    pub variant: Option<String>,
+}
+
+impl From<InsertArgs> for FilterArgs {
+    fn from(args: InsertArgs) -> Self {
+        FilterArgs {
+            job_title: Some(args.job_title),
+            company_name: Some(args.company_name),
+            quote: args.quote,
+            date: None,
+            variant: args.variant,
+        }
+    }
 }
 
 #[derive(Args, Debug, Clone, Default)]
@@ -70,27 +104,27 @@ pub struct FilterArgs {
     pub variant: Option<String>,
 }
 
-pub fn match_user_action(ctx: &AppContext, user_input: UserInput) -> String {
+pub fn match_user_action(
+    ctx: &AppContext,
+    user_input: UserInput,
+) -> Result<String, Box<dyn std::error::Error>> {
     match user_input.action {
-        UserAction::Insert(_insert_args) => match insert_cv(ctx) {
-            Ok(s) => s,
-            Err(e) => panic!("{e:?}"),
-        },
+        UserAction::Insert(_) => insert_cv(ctx),
 
         UserAction::Remove(filters) => {
             let _ = remove_cv(ctx, &filters);
             let out = format!("filter args for LIST: {filters:?}");
             println!("{out:?}");
-            out
+            Ok(out)
         }
         UserAction::List(_filters) => {
-            run_list_tui(ctx).unwrap_or_else(|e| panic!("{e:?}"));
-            String::from("tui: ok")
+            run_list_tui(ctx)?;
+            Ok(String::from("tui: ok"))
         }
         UserAction::Update(filters) => {
             let out = format!("filter args for UPDATE: {filters:?}");
             println!("{out:?}");
-            out
+            Ok(out)
         }
     }
 }
@@ -190,7 +224,8 @@ mod tests {
         let out = match_user_action(
             &ctx,
             user_input_with(UserAction::Update(FilterArgs::default())),
-        );
+        )
+        .unwrap();
         assert!(out.contains("UPDATE"));
     }
 }

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -100,7 +100,7 @@ mod tests {
 
     fn empty_context() -> AppContext {
         let ui = UserInput {
-            action: UserAction::Insert(FilterArgs::default()),
+            action: UserAction::List(FilterArgs::default()),
             save_to_database: false,
             view_generated_cv: false,
             dry_run: false,
@@ -122,7 +122,7 @@ mod tests {
         let mut f = NamedTempFile::new().unwrap();
         writeln!(f, "[db]\ndb_path = \"/tmp\"\ndb_file = \"test.db\"").unwrap();
         let ui = UserInput {
-            action: UserAction::Insert(FilterArgs::default()),
+            action: UserAction::List(FilterArgs::default()),
             save_to_database: false,
             view_generated_cv: false,
             dry_run: false,

--- a/src/cv_insert.rs
+++ b/src/cv_insert.rs
@@ -88,7 +88,7 @@ mod tests {
 
     fn context_without_job_title() -> AppContext {
         let ui = UserInput {
-            action: UserAction::Insert(FilterArgs::default()),
+            action: UserAction::Update(FilterArgs::default()),
             save_to_database: false,
             view_generated_cv: false,
             dry_run: false,
@@ -114,6 +114,8 @@ mod tests {
     fn test_insert_cv_errors_when_job_title_missing() {
         // A FilterArgs without a job_title cannot drive a CV build: insert_cv
         // surfaces the error instead of relying on a (now removed) global panic.
+        // clap now ALSO guards this at the CLI boundary for `insert` (required
+        // job_title/company_name); this remains a defensive check on insert_cv.
         let ctx = context_without_job_title();
         assert!(insert_cv(&ctx).is_err());
     }

--- a/src/file_handlers.rs
+++ b/src/file_handlers.rs
@@ -486,7 +486,7 @@ mod tests {
         fs::write(&ini_path, ini).unwrap();
 
         let ui = crate::cli_structure::UserInput {
-            action: crate::cli_structure::UserAction::Insert(
+            action: crate::cli_structure::UserAction::List(
                 crate::cli_structure::FilterArgs::default(),
             ),
             save_to_database: false,

--- a/src/global_conf.rs
+++ b/src/global_conf.rs
@@ -71,8 +71,8 @@ impl AppContext {
 
     pub fn get_user_input_action_filter_args(&self) -> FilterArgs {
         match self.get_user_input_action() {
-            UserAction::Insert(filter_args)
-            | UserAction::Remove(filter_args)
+            UserAction::Insert(insert_args) => insert_args.into(),
+            UserAction::Remove(filter_args)
             | UserAction::List(filter_args)
             | UserAction::Update(filter_args) => filter_args,
         }
@@ -149,7 +149,7 @@ mod tests {
 
     fn dummy_user_input() -> UserInput {
         UserInput {
-            action: UserAction::Insert(FilterArgs {
+            action: UserAction::List(FilterArgs {
                 job_title: Some("Dev".to_string()),
                 company_name: Some("Company".to_string()),
                 quote: Some("Quote".to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,13 @@ fn main() {
 
     let _action: UserAction = ctx.get_user_input_action();
 
-    let cv_full_path = match_user_action(&ctx, user_input.clone());
+    let cv_full_path = match match_user_action(&ctx, user_input.clone()) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    };
 
     if !cv_full_path.is_empty() {
         if user_input.view_generated_cv {
@@ -157,7 +163,7 @@ mod tests {
         std::fs::write(&ini_path, ini).unwrap();
 
         let ui = UserInput {
-            action: UserAction::Insert(cli_structure::FilterArgs::default()),
+            action: UserAction::List(cli_structure::FilterArgs::default()),
             save_to_database: false,
             view_generated_cv: false,
             dry_run: false,

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -36,6 +36,24 @@ fn test_insert_help_lists_variant_flag() {
 }
 
 #[test]
+fn test_insert_without_required_args_errors_with_help() {
+    let out = bin().arg("insert").output().expect("failed to run insert");
+    assert!(
+        !out.status.success(),
+        "insert with no args should exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("required") || stderr.contains("Usage"),
+        "should print a usage/required-args helper, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked"),
+        "must not panic, got: {stderr}"
+    );
+}
+
+#[test]
 fn test_no_subcommand_is_an_error() {
     // A subcommand is required; clap should reject invocation with no action
     // and exit non-zero before any side effects.


### PR DESCRIPTION
## Problem

Running `insert` (and other subcommands) without the params it needs
**panicked** with a Rust backtrace instead of showing a helpful usage error:

- `match_user_action` used `Err(e) => panic!(\"{e:?}\")` (insert) and
  `run_list_tui(ctx).unwrap_or_else(|e| panic!(...))` (list).
- All `FilterArgs` fields were `Option<String>`, so clap never enforced
  `--job-title`/`--company-name` for `insert`; the missing values flowed into
  `insert_cv` → `ctx.get_job_title()?` → the panic above.

## Fix

- **`insert` gets a dedicated `InsertArgs`** with **required** `--job-title` and
  `--company-name` (plus optional `--quote`/`--variant`). clap now prints a clean
  usage helper and exits 2 instead of panicking. `update`/`remove`/`list` keep the
  all-optional `FilterArgs` (they use those fields as filters).
- `From<InsertArgs> for FilterArgs` + the `get_user_input_action_filter_args`
  mapping keep `insert_cv` unchanged.
- **`match_user_action` returns `Result`** (both `panic!`s removed); `main` prints
  `Error: …` to stderr and exits 1 on any runtime error — no more backtraces.

## Behavior

```
$ rusty_cv_creator insert
error: the following required arguments were not provided:
  --job-title <JOB_TITLE>
  --company-name <COMPANY_NAME>

Usage: rusty_cv_creator insert --job-title <JOB_TITLE> --company-name <COMPANY_NAME>

For more information, try '--help'.
$ echo $?
2
```

## Tests

All green (123 passed / 0 failed). Adds a `cli_smoke` regression test
`test_insert_without_required_args_errors_with_help` asserting `insert` with no
args exits non-zero, prints a usage/required-args helper, and does **not** panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)