### PR TITLE
ci: clear Node 20 deprecation warnings in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 🛠️ Build
         run: cargo build --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: 🛠️ Setup Rust
@@ -17,7 +17,7 @@ jobs:
         run: cargo install cargo-edit
       - name: 🎨 Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v5
+        uses: TriPSs/conventional-changelog-action@v6
         with:
           # conventionalcommits preset honours the `!` breaking shorthand
           # (feat!:, fix!:) and BREAKING CHANGE: footers → major bump. The

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: 🧪 Tests, Lint & Format (devenv)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: ❄️ Install Nix
         uses: cachix/install-nix-action@v27
         with:
@@ -41,7 +41,7 @@ jobs:
     # nightly toolchain / coverage tooling may break from time to time
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: ❄️ Install Nix
         uses: cachix/install-nix-action@v27
         with:
@@ -57,7 +57,7 @@ jobs:
             cargo llvm-cov report --doctests --lcov --output-path lcov.info --ignore-filename-regex "schema\.rs"
           '
       - name: 💭 Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         env:
           token: ${{ secrets.CODECOV_TOKEN }}
         with:


### PR DESCRIPTION
## What

Clear the Node 20 deprecation warnings surfaced in every CI job (GitHub
runners now force Node 20 actions onto Node 24 and warn).

## Changes

- `actions/checkout` v4 -> v5 (Node 24) in build, tests, release
- `codecov/codecov-action` v5 -> v7 — drops the transitive
  `actions/github-script@Node20` warning; coverage job is
  `continue-on-error` so zero pipeline risk
- `TriPSs/conventional-changelog-action` v5 -> v6 (Node 24); every input
  we pass is still supported in v6, release behaviour unchanged
- `install-nix-action` left at v27 (composite action, not Node 20 flagged)

## Note

Release automation is separately broken by the `branch-discipline`
ruleset (direct push to master rejected) — tracked outside this PR.
