### PR TITLE
ci(release): land the version bump through a pull request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,12 @@ name: 🎯 Release
 on:
   push:
     branches: [master]
+permissions:
+  contents: write
+  pull-requests: write
+concurrency:
+  group: release
+  cancel-in-progress: false
 env:
   CARGO_TERM_COLOR: always
 jobs:
@@ -24,29 +30,82 @@ jobs:
           # default angular preset ignored `feat!:` and shipped a breaking
           # change as a patch (v4.0.3); see ADR-0007.
           preset: "conventionalcommits"
-          git-user-name: "chess-seventh"
-          git-user-email: "chess7th@pm.me"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          git-message: "ci: version bump"
           output-file: "CHANGELOG.md"
           release-count: "0"
-          skip-version-file: "false"
-          skip-commit: "false"
           skip-on-empty: "false"
           version-file: "Cargo.toml"
           version-path: "package.version"
           create-summary: "true"
-      - name: 🛠️ Update Cargo.toml version
+          # This job owns every git operation; the action only computes the
+          # version and writes CHANGELOG.md. It must never push: master is
+          # protected by the branch-discipline ruleset (PR required, no bypass
+          # actor), and a tag pushed alongside a rejected commit is how v5.3.1
+          # ended up orphaned. Tagging waits until the PR is merged.
+          # NOTE: skip-commit also routes the version lookup to git tags, so
+          # the action no longer rewrites Cargo.toml - the cargo set-version
+          # step below owns that.
+          skip-commit: "true"
+          skip-tag: "true"
+          git-push: "false"
+      - name: 🛠️ Update Cargo.toml and Cargo.lock
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: |
-          cargo set-version ${{ steps.changelog.outputs.version }}
+          cargo set-version "${{ steps.changelog.outputs.version }}"
+          # Scoped to this crate on purpose: a bare `cargo update` would drag a
+          # full dependency refresh into a release PR that runs no CI.
+          cargo update -p rusty_cv_creator
           cargo build --verbose
-          cargo update
+      - name: 📤 Open the version-bump pull request
+        id: bump_pr
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.changelog.outputs.version }}
+          BRANCH: release-bot/${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          # The branch is cut here, after the changelog action has run: the
+          # action pulls the checked-out branch, which only works while master
+          # is still the current branch. The file edits carry over untouched.
+          git switch -c "${BRANCH}"
           git config user.name "chess-seventh"
           git config user.email "chess7th@pm.me"
-          git add Cargo.lock
-          git commit -m "chore: update Cargo.lock [skip ci]"
-          git push
+          git add CHANGELOG.md Cargo.toml Cargo.lock
+          git commit -m "chore(release): v${VERSION}"
+          git push origin "${BRANCH}"
+          echo "bump_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          gh pr create \
+            --base master \
+            --head "${BRANCH}" \
+            --title "chore(release): v${VERSION}" \
+            --body "Automated version bump for v${VERSION}, opened and merged by the Release workflow."
+      - name: 🔀 Merge the pull request
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: release-bot/${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          # Mergeability is computed asynchronously, so a merge fired straight
+          # after the create can still see UNKNOWN. Wait it out.
+          state=UNKNOWN
+          for _ in $(seq 1 30); do
+            state=$(gh pr view "${BRANCH}" --json mergeable --jq .mergeable || echo UNKNOWN)
+            [ "${state}" = "MERGEABLE" ] && break
+            echo "waiting for mergeability, currently ${state}"
+            sleep 5
+          done
+          if [ "${state}" != "MERGEABLE" ]; then
+            echo "::error::gave up waiting for mergeability, last state ${state}"
+            exit 1
+          fi
+          # A merge commit, never a squash: the release tag points at the bump
+          # commit, and a squash would rewrite that SHA off master's history.
+          # The ruleset requires no status checks, so the merge lands at once.
+          # The repo reaps the branch itself (delete_branch_on_merge), so this
+          # step never risks the release on a cleanup failure.
+          gh pr merge "${BRANCH}" --merge
       - name: ✨ Create Release
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         uses: ncipollo/release-action@v1
@@ -54,4 +113,5 @@ jobs:
           tag: ${{ steps.changelog.outputs.tag }}
           name: ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
+          commit: ${{ steps.bump_pr.outputs.bump_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -376,6 +376,26 @@ diesel migration run
 cargo test
 ```
 
+### 🎯 Releasing
+
+Releases are fully automated - never bump the version by hand.
+
+Every push to `master` runs the Release workflow, which:
+
+1. derives the next version and the changelog from the conventional-commit
+   history (`feat!:` / `BREAKING CHANGE:` -> major, `feat:` -> minor, `fix:` ->
+   patch);
+2. writes `CHANGELOG.md`, `Cargo.toml` and `Cargo.lock`, then opens a
+   `release-bot/<run-id>-<attempt>` pull request with that bump;
+3. merges that PR itself (merge commit, never squash) using the built-in
+   `GITHUB_TOKEN`;
+4. tags the merged bump commit and publishes the GitHub release.
+
+`master` is protected by the `branch-discipline` ruleset - a pull request is
+required and there is no bypass actor - so the bot goes through a PR like
+everyone else. The tag is created only *after* the PR merges, which is what
+keeps a failed release from leaving an orphan tag behind.
+
 ## 🌟 Roadmap
 
 - [ ] **Web Interface**: Browser-based CV management

--- a/docs/feature/ci-release-hardening/devops/wave-decisions.md
+++ b/docs/feature/ci-release-hardening/devops/wave-decisions.md
@@ -16,6 +16,8 @@
 | 5 | Keep triggers `push`+`pull_request` to `master`. | Correct for GitHub Flow; no change needed. | feature-delta |
 | 6 | Do NOT add mutation testing; record `nightly-delta` as intended/not-yet-wired; do NOT edit `CLAUDE.md`. | No tooling exists; out of scope this pass. | feature-delta |
 | 7 | CI uses `cargo fmt --check`, not `treefmt`; accept treefmt as a local superset. | Avoid provisioning nix in CI; revisit only on rustfmt edition/skip_children drift. | ADR-0007 alt A |
+| 8 | `release.yml` lands its version bump through a bot-opened, bot-merged pull request instead of pushing to `master`; the tag is created only after that PR merges. | The `branch-discipline` ruleset requires a PR on `master` with no bypass actor, so the direct push failed with GH013 and left the version stuck at 5.3.0 plus an orphan `v5.3.1` tag. Making the automation compliant beats weakening the ruleset. | L66 |
+| 9 | Delete the orphan `v5.3.1` tag on the remote before the first run of the new flow. | The version lookup walks reachable tags only, so the unreachable `v5.3.1` is invisible: the run computes 5.3.1 again from `v5.3.0`, and the release API silently attaches that release to the pre-existing orphan tag at `63f7d0b` instead of the merged bump commit. Every later run recomputes the same collision, so the pipeline stays stuck until the tag is gone. | L66 |
 
 ## Production Readiness Summary
 
@@ -34,9 +36,12 @@ production-readiness checklist is applied in its CI-relevant subset:
 ## Deployment Strategy
 
 Recreate / N-A — GitHub Release artifact via `release.yml`
-(conventional-changelog-action) on `master` push. No canary/blue-green (no
-service). **Rollback = re-tag-forward** (preferred), or mark the bad GitHub
-Release as pre-release, or `cargo yank` if crates.io publishing is ever wired.
+(conventional-changelog-action) on `master` push. Since decision 8 the workflow
+writes nothing to `master` directly: it opens a `release-bot/<run-id>-<attempt>` PR with
+the bump, merges it with the built-in `GITHUB_TOKEN`, then tags the bump commit
+the merge brought in. No canary/blue-green (no service). **Rollback = re-tag-forward**
+(preferred), or mark the bad GitHub Release as pre-release, or `cargo yank` if
+crates.io publishing is ever wired.
 
 ## Stakeholder / Sign-off
 
@@ -48,7 +53,9 @@ mechanism remains. Sign-off = PR merge to `master`.
 ## Constraints
 
 - DOCS-ONLY this wave; no `.yml`/`.releaserc*`/source edits until apply step.
-- Behavior-preserving for the release pipeline (deletions target unreferenced files).
+- Behavior-preserving for the release pipeline (deletions target unreferenced
+  files). Superseded for `release.yml` by decision 8, which deliberately changes
+  how the bump reaches `master` - the ruleset left the old behavior unusable.
 - No new dependencies, no new platform, no container/orchestration.
 - GitHub Flow triggers unchanged.
 
@@ -59,6 +66,7 @@ mechanism remains. Sign-off = PR merge to `master`.
 | `.github/workflows/rust-tests.yml` | EDIT | CHANGE 1 (clippy `-D warnings` step + advisory pedantic), CHANGE 2 (uncomment/enable `rustfmt` job), CHANGE 3 (add `threaded-test` job) |
 | `.releaserc.yml` | DELETE | CHANGE 4 (dormant semantic-release config) |
 | `.releaserc` | DELETE | CHANGE 4 (dormant semantic-release branches) |
+| `.github/workflows/release.yml` | EDIT | Decision 8 (bump lands via a bot pull request; tag created after the merge) |
 
 ## Upstream Changes
 


### PR DESCRIPTION
Reworks the release automation so the version bump reaches master through a bot-opened, bot-merged pull request instead of a direct push blocked by the branch-discipline ruleset.

- changelog action computes the version and writes CHANGELOG.md only
- cargo set-version owns Cargo.toml; cargo update scoped to this crate
- bump committed on release-bot/<run-id>-<attempt>, merged as a merge commit
- tag and GitHub release created only after that merge
- README + ci-release-hardening wave decisions updated

Prerequisite already done: the orphan v5.3.1 tag was deleted on the remote.

Refs: L66