### PR TITLE
chore(devenv): bump rusty-commit-saver and make the release retryable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,25 @@ jobs:
           git config user.name "chess-seventh"
           git config user.email "chess7th@pm.me"
           git add CHANGELOG.md Cargo.toml Cargo.lock
+          # A re-run of a job that already merged its bump has nothing to stage:
+          # the version, the lock and the changelog all match master already.
+          # Point at the bump commit that landed and let the tag step finish the
+          # release, instead of dying on an empty commit.
+          if git diff --cached --quiet; then
+            # -F is not usable with the anchors, so escape the dots instead;
+            # --no-merges skips the merge commit, whose default body is the pull
+            # request title and therefore matches the same pattern.
+            esc=$(printf '%s' "${VERSION}" | sed 's/\./\\./g')
+            landed=$(git log -1 --no-merges --format=%H --grep="^chore(release): v${esc}$" master)
+            if [ -z "${landed}" ]; then
+              echo "::error::v${VERSION} produced no changes and no bump commit exists on master"
+              exit 1
+            fi
+            echo "v${VERSION} already landed as ${landed}; skipping the pull request"
+            echo "bump_sha=${landed}" >> "$GITHUB_OUTPUT"
+            echo "already_landed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git commit -m "chore(release): v${VERSION}"
           git push origin "${BRANCH}"
           echo "bump_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -81,7 +100,7 @@ jobs:
             --title "chore(release): v${VERSION}" \
             --body "Automated version bump for v${VERSION}, opened and merged by the Release workflow."
       - name: 🔀 Merge the pull request
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        if: ${{ steps.changelog.outputs.skipped == 'false' && steps.bump_pr.outputs.already_landed != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: release-bot/${{ github.run_id }}-${{ github.run_attempt }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,1 @@
-/nix/store/j97dq0mnp4iffb3wzinsrzxsk5qp83vi-pre-commit-config.json
+/nix/store/3yxihli865cyxw9qamc9i2kx0pd6y5av-pre-commit-config.json

--- a/devenv.lock
+++ b/devenv.lock
@@ -180,11 +180,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1764211126,
-        "narHash": "sha256-p5y13PnMZYd5WdHk+XCzyUaLGBUCwnz2n4KYKEZM0Pw=",
+        "lastModified": 1782098508,
+        "narHash": "sha256-YeBVH+avasLg/ZTOyshNI4qfU8p5RbMs9O8944A1QDg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "895935bff08cfcfb663fb9c8263c43596e7cd1ed",
+        "rev": "67eed429b53d462923d9be580cfc9ed372f7564f",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1777045433,
-        "narHash": "sha256-unyy0WFlyC85TuWPwlY1SX6e39X3zTXzyMQJiaK5hZk=",
+        "lastModified": 1785061245,
+        "narHash": "sha256-oihg7f5013W+uHMYBYswYYwPCvMKK6yQj01X1h2IEs8=",
         "owner": "chess-seventh",
         "repo": "rusty-commit-saver",
-        "rev": "9346c64ed617acd66c3c405d164b339e89c06b35",
+        "rev": "cfcc662cb16ab80ddd4370e72c06b038a2b6566b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Two fixes:

- bump the rusty-commit-saver devenv input 4.14.2 -> 4.17.1; the old pin predates the [exclude] ini section and panicked on every commit
- re-sync the tracked .pre-commit-config.yaml symlink, which still pointed the post-commit hook at the 4.14.2 binary
- make release.yml able to finish a release whose version-bump PR already merged, instead of dying on an empty commit

Refs: L66