### PR TITLE
chore(hooks): stop tracking the generated pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,0 @@
-/nix/store/3yxihli865cyxw9qamc9i2kx0pd6y5av-pre-commit-config.json


### PR DESCRIPTION
`.pre-commit-config.yaml` is generated by devenv and is a symlink into /nix/store, yet it was both tracked and gitignored. Every lock change made the tracked value stale, which is how the saver bump landed while the committed hook still pointed at the panicking 4.14.2 build.

Refs: L66