### PR TITLE
fix(security): take the database password out of the tracked tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,15 @@ DATABASE_URL="sqlite://$HOME/.config/rusty-cv-creator/applications.db" diesel se
 the whole SQLite path. Do not follow it with `diesel migration run`: the
 migration declares `id SERIAL PRIMARY KEY`, which `diesel-cli` will not reflect
 back for SQLite, so the command exits 1 with ``Unsupported type: `serial` ``.
-The database is already correct at that point; only the schema printer fails.
-Against a PostgreSQL target both commands succeed.
+
+On SQLite the table the migration produces is **not usable by this program**:
+`SERIAL` is not `INTEGER PRIMARY KEY` there, so `id` is not a rowid alias and
+does not autoincrement — every insert and read then fails with
+`UnexpectedNullError`. The migration is written for PostgreSQL. If you want a
+working SQLite database today, create the table with
+`id INTEGER PRIMARY KEY AUTOINCREMENT`, which is what the test fixtures in
+`src/database.rs` do. Against a PostgreSQL target both commands succeed and the
+schema is correct.
 
 For a PostgreSQL target, build that inline URL from your `db_pg_host` plus the
 password — it is a `diesel-cli` invocation, not this program, so it takes the

--- a/README.md
+++ b/README.md
@@ -167,8 +167,12 @@ The SQLite path reads `DATABASE_URL` from the environment, falling back to the
 `[db] db_path` / `db_file` values in your config file:
 
 ```bash
-echo "DATABASE_URL=sqlite://$HOME/.config/rusty-cv-creator/applications.db" > .env
+cp env.sample .env   # then edit it
 ```
+
+Append rather than overwrite if you already have a `.env`: on the PostgreSQL
+path it also holds `RUSTY_CV_DB_PASSWORD`, and a truncating `>` would destroy
+it.
 
 #### PostgreSQL (for advanced users)
 
@@ -206,7 +210,10 @@ Two rules the program enforces, both with an actionable error:
 
 - a missing or empty `RUSTY_CV_DB_PASSWORD` is a hard failure — there is no
   passwordless fallback connect;
-- a `db_pg_host` that still carries a password is rejected. Remove the password
+- a `db_pg_host` that still carries a password is rejected — both forms, before
+  the `@` and as a `?password=` query parameter. The query form matters because
+  PostgreSQL *prefers* it over the spliced one, so accepting it would let a
+  config-file password silently beat the sops-supplied one. Remove the password
   from your config file: it now comes only from the environment.
 
 #### Run and test it

--- a/README.md
+++ b/README.md
@@ -189,8 +189,10 @@ The PostgreSQL path does **not** read `DATABASE_URL`. It reads two things:
    reads the value, percent-encodes it, splices it into the URL immediately
    before connecting, and writes it nowhere — not into a file in this
    repository, and not back into the environment. Every subprocess it spawns
-   (the PDF viewer, `xdg-open`, `git`, `sudo`, `tailscale`) is started with the
-   variable removed, so the password stops at this process.
+   (the PDF viewer, `xdg-open`, `git`, `sudo`, `tailscale`) is started with
+   both `RUSTY_CV_DB_PASSWORD` and `DATABASE_URL` removed, so no credential
+   reaches a child - not even from an unmigrated config whose `db_pg_host`
+   still carries an inline password.
 
 Where the variable comes from:
 
@@ -222,9 +224,19 @@ exports one (it used to, with a credential in it), so put the SQLite URL in
 `.env` — see `env.sample` — or pass a URL inline for the migration command only:
 
 ```bash
+# option A: from .env (copy env.sample and edit it), then
 diesel setup
 diesel migration run
+
+# option B: inline, without persisting anything
+DATABASE_URL="sqlite://$HOME/.config/rusty-cv-creator/applications.db" diesel setup
+DATABASE_URL="sqlite://$HOME/.config/rusty-cv-creator/applications.db" diesel migration run
 ```
+
+For a PostgreSQL target, build that inline URL from your `db_pg_host` plus the
+password — it is a `diesel-cli` invocation, not this program, so it takes the
+whole URL. Do not write that URL into a tracked file; the credential scanner
+will fail the build if you do.
 
 ### Template Structure
 

--- a/README.md
+++ b/README.md
@@ -183,10 +183,14 @@ The PostgreSQL path does **not** read `DATABASE_URL`. It reads two things:
    db_pg_host = "postgres://<user>@<host>/<database>"
    ```
 
-2. The password, from the `RUSTY_CV_DB_PASSWORD` environment variable. It is
-   percent-encoded and spliced into the URL immediately before connecting, and
-   is never written into the process environment nor into any file in this
-   repository.
+2. The password, from the `RUSTY_CV_DB_PASSWORD` environment variable. The
+   variable **is** in this process's environment — that is deliberate, it is
+   how the password reaches the program. What the program does with it: it
+   reads the value, percent-encodes it, splices it into the URL immediately
+   before connecting, and writes it nowhere — not into a file in this
+   repository, and not back into the environment. Every subprocess it spawns
+   (the PDF viewer, `xdg-open`, `git`, `sudo`, `tailscale`) is started with the
+   variable removed, so the password stops at this process.
 
 Where the variable comes from:
 

--- a/README.md
+++ b/README.md
@@ -228,12 +228,17 @@ exports one (it used to, with a credential in it), so put the SQLite URL in
 ```bash
 # option A: from .env (copy env.sample and edit it), then
 diesel setup
-diesel migration run
 
 # option B: inline, without persisting anything
 DATABASE_URL="sqlite://$HOME/.config/rusty-cv-creator/applications.db" diesel setup
-DATABASE_URL="sqlite://$HOME/.config/rusty-cv-creator/applications.db" diesel migration run
 ```
+
+`diesel setup` creates the database **and** applies the migrations — that is
+the whole SQLite path. Do not follow it with `diesel migration run`: the
+migration declares `id SERIAL PRIMARY KEY`, which `diesel-cli` will not reflect
+back for SQLite, so the command exits 1 with ``Unsupported type: `serial` ``.
+The database is already correct at that point; only the schema printer fails.
+Against a PostgreSQL target both commands succeed.
 
 For a PostgreSQL target, build that inline URL from your `db_pg_host` plus the
 password — it is a `diesel-cli` invocation, not this program, so it takes the

--- a/README.md
+++ b/README.md
@@ -176,7 +176,10 @@ it.
 
 #### PostgreSQL (for advanced users)
 
-The PostgreSQL path does **not** read `DATABASE_URL`. It reads two things:
+The PostgreSQL path does **not** connect using `DATABASE_URL`. (Startup still
+touches that variable — when it is unset the program writes `db_pg_host` into
+it — but nothing on the connect path reads it back, and it is stripped from
+every child process.) The connection is built from two things:
 
 1. `[db] db_pg_host` in your config file — a **passwordless** connection URL
    naming the scheme, the database user, the host and the database:

--- a/README.md
+++ b/README.md
@@ -190,9 +190,11 @@ The PostgreSQL path does **not** read `DATABASE_URL`. It reads two things:
    before connecting, and writes it nowhere — not into a file in this
    repository, and not back into the environment. Every subprocess it spawns
    (the PDF viewer, `xdg-open`, `git`, `sudo`, `tailscale`) is started with
-   both `RUSTY_CV_DB_PASSWORD` and `DATABASE_URL` removed, so no credential
-   reaches a child - not even from an unmigrated config whose `db_pg_host`
-   still carries an inline password.
+   both `RUSTY_CV_DB_PASSWORD` and `DATABASE_URL` removed, so no **database**
+   credential reaches a child - not even from an unmigrated config whose
+   `db_pg_host` still carries an inline password. `GITHUB_TOKEN` is a known
+   exception: `git` needs it, so it is still inherited by every child. Closing
+   that is tracked separately.
 
 Where the variable comes from:
 

--- a/README.md
+++ b/README.md
@@ -161,17 +161,61 @@ rusty_cv_creator insert "StartupCo" "Backend Engineer" "Excited about scaling ch
 
 ### Database Setup
 
-Set your database URL in your environment or `.env` file:
+#### SQLite (recommended for single user)
+
+The SQLite path reads `DATABASE_URL` from the environment, falling back to the
+`[db] db_path` / `db_file` values in your config file:
 
 ```bash
-# SQLite (recommended for single user)
 echo "DATABASE_URL=sqlite://$HOME/.config/rusty-cv-creator/applications.db" > .env
-
-# PostgreSQL (for advanced users)
-echo "DATABASE_URL=postgresql://user:password@localhost/cv_db" > .env
 ```
 
-Initialize the database:
+#### PostgreSQL (for advanced users)
+
+The PostgreSQL path does **not** read `DATABASE_URL`. It reads two things:
+
+1. `[db] db_pg_host` in your config file — a **passwordless** connection URL
+   naming the scheme, the database user, the host and the database:
+
+   ```ini
+   [db]
+   engine = "postgres"
+   db_pg_host = "postgres://<user>@<host>/<database>"
+   ```
+
+2. The password, from the `RUSTY_CV_DB_PASSWORD` environment variable. It is
+   percent-encoded and spliced into the URL immediately before connecting, and
+   is never written into the process environment nor into any file in this
+   repository.
+
+Where the variable comes from:
+
+- on the real machine, sops supplies it through home-manager, exported into the
+  user session environment so non-interactive invocations see it too;
+- in development, from the gitignored `.env` file at the root of this repo.
+
+Two rules the program enforces, both with an actionable error:
+
+- a missing or empty `RUSTY_CV_DB_PASSWORD` is a hard failure — there is no
+  passwordless fallback connect;
+- a `db_pg_host` that still carries a password is rejected. Remove the password
+  from your config file: it now comes only from the environment.
+
+#### Run and test it
+
+```bash
+# development: supply the password for this shell only
+read -rs RUSTY_CV_DB_PASSWORD && export RUSTY_CV_DB_PASSWORD
+
+# check the resolution and the credential scanner
+devenv shell -- cargo nextest run --no-fail-fast
+```
+
+#### Initialize the database
+
+`diesel-cli` reads `DATABASE_URL` from the environment. The dev shell no longer
+exports one (it used to, with a credential in it), so put the SQLite URL in
+`.env` — see `env.sample` — or pass a URL inline for the migration command only:
 
 ```bash
 diesel setup

--- a/README.md
+++ b/README.md
@@ -210,11 +210,16 @@ Two rules the program enforces, both with an actionable error:
 
 - a missing or empty `RUSTY_CV_DB_PASSWORD` is a hard failure — there is no
   passwordless fallback connect;
-- a `db_pg_host` that still carries a password is rejected — both forms, before
-  the `@` and as a `?password=` query parameter. The query form matters because
-  PostgreSQL *prefers* it over the spliced one, so accepting it would let a
-  config-file password silently beat the sops-supplied one. Remove the password
-  from your config file: it now comes only from the environment.
+- a `db_pg_host` that still carries a password is rejected: before the `@`, or
+  as a query parameter whose name means a password. The query form matters
+  because PostgreSQL *prefers* it over the spliced one, so accepting it would
+  let a config-file password silently beat the sops-supplied one. Parameter
+  names are percent-decoded before the check (PostgreSQL decodes them too, so
+  `?%70assword=` is the same parameter), an empty value counts — it discards
+  the supplied password and falls through to `.pgpass` — and any name
+  containing "password", such as `sslpassword`, is treated the same way.
+  Remove the password from your config file: it now comes only from the
+  environment.
 
 #### Run and test it
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -22,7 +22,11 @@
   dotenv.enable = true;
 
   env.GREET = "Welcome to the Rusty CV Creator";
-  env.DATABASE_URL = "postgres://rusty_cv:rusty-cv-01@nixos-03.caracara-palermo.ts.net/db_rusty_cv";
+  # This file must never carry credentials. The postgres password is read at
+  # runtime from RUSTY_CV_DB_PASSWORD, supplied by sops via home-manager on the
+  # real machine, or by the gitignored .env in development.
+  # diesel-cli in this dev shell still needs DATABASE_URL: set it in .env
+  # (see env.sample), since it is no longer exported from here.
 
   packages = with pkgs; [
     zlib

--- a/docs/feature/fix-db-credentials-from-sops/deliver/roadmap.json
+++ b/docs/feature/fix-db-credentials-from-sops/deliver/roadmap.json
@@ -1,0 +1,73 @@
+{
+  "roadmap": {
+    "project_id": "fix-db-credentials-from-sops",
+    "created_at": "2026-07-30T21:00:00Z",
+    "total_steps": 2,
+    "goal": "Remove the plaintext PostgreSQL password from the tracked tree, source it at runtime from RUSTY_CV_DB_PASSWORD, and reconcile the database host and name onto nixos-02/rusty_cv.",
+    "note": "Bugfix flow (lane L74). RCA at ../rca.md. Two steps: a failing regression net first, then the fix that turns it green. Scope approved by the maintainer includes de-quoting the DB accessors (without it the engine name never matches and the postgres path cannot connect at all) and making a swallowed DB error visible. Explicitly OUT of scope: the sqlite arm receiving a postgres URL from the dev shell, which gets its own lane.",
+    "validation": {
+      "status": "approved",
+      "by": "maintainer",
+      "rationale": "scope chosen at the bugfix Phase-2 review gate"
+    }
+  },
+  "phases": [
+    {
+      "id": "01",
+      "name": "Credentials out of the tree, password from the environment",
+      "default_agent": "nw-software-crafter",
+      "default_deps_strategy": "sequential",
+      "steps": [
+        {
+          "id": "01-01",
+          "name": "Regression net: no credential literals, loud failure, quoted values",
+          "criteria": [
+            "A test walks the tracked tree and fails on any URL carrying inline userinfo credentials (scheme://user:secret@host), covering .nix, .ini, .rs, .md and .toml files.",
+            "A test proves resolve_db_target on the postgres arm returns an error naming RUSTY_CV_DB_PASSWORD when that variable is unset or empty.",
+            "A test proves a config whose values are quoted (the documented example format) still resolves engine postgres and a usable URL.",
+            "A test proves a base URL that already carries a password is rejected rather than double-spliced.",
+            "Every new test fails against current code for the stated reason, not by compile error alone."
+          ],
+          "agent": "nw-software-crafter",
+          "deps": [],
+          "test_file": "tests/regression/db_credentials.rs plus in-crate cfg(test) modules",
+          "scenario_name": "n/a defect regression net",
+          "files_to_modify": [
+            "tests/regression/db_credentials.rs",
+            "src/config_parse.rs",
+            "src/global_conf.rs"
+          ]
+        },
+        {
+          "id": "01-02",
+          "name": "Fix: strip the literals, splice the password, reconcile the host",
+          "criteria": [
+            "No inline-credential URL remains anywhere in the tracked tree, test fixtures included.",
+            "devenv.nix no longer sets DATABASE_URL to a credential-bearing value.",
+            "rusty-cv-config-example.ini points at nixos-02 with database rusty_cv and carries no password.",
+            "The postgres arm reads RUSTY_CV_DB_PASSWORD, percent-encodes it, and splices it into the configured URL immediately before connecting; the password is never written into the process environment.",
+            "A missing or empty variable fails with an actionable message; there is no passwordless fallback connect.",
+            "The database accessors strip surrounding quotes, so a quoted config resolves correctly.",
+            "A database error on the insert path is reported at error level instead of being swallowed at warn level.",
+            "The sqlite path is unchanged; all 169 pre-existing tests still pass; treefmt and clippy -D warnings clean; no new runtime dependency."
+          ],
+          "agent": "nw-software-crafter",
+          "deps": ["01-01"],
+          "test_file": "tests/regression/db_credentials.rs plus in-crate cfg(test) modules",
+          "scenario_name": "n/a defect fix",
+          "files_to_modify": [
+            "devenv.nix",
+            "rusty-cv-config-example.ini",
+            "src/config_parse.rs",
+            "src/global_conf.rs",
+            "src/cv_insert.rs",
+            "src/cli_structure.rs",
+            "tests/integration-tests.rs",
+            "README.md",
+            "docs/product/architecture/brief.md"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/feature/fix-db-credentials-from-sops/deliver/roadmap.json
+++ b/docs/feature/fix-db-credentials-from-sops/deliver/roadmap.json
@@ -22,7 +22,7 @@
           "id": "01-01",
           "name": "Regression net: no credential literals, loud failure, quoted values",
           "criteria": [
-            "A test walks the tracked tree and fails on any URL carrying inline userinfo credentials (scheme://user:secret@host), covering .nix, .ini, .rs, .md and .toml files.",
+            "A test walks the tracked tree and fails on any URL carrying a password in its userinfo, covering every tracked file except markdown prose and binaries.",
             "A test proves resolve_db_target on the postgres arm returns an error naming RUSTY_CV_DB_PASSWORD when that variable is unset or empty.",
             "A test proves a config whose values are quoted (the documented example format) still resolves engine postgres and a usable URL.",
             "A test proves a base URL that already carries a password is rejected rather than double-spliced.",

--- a/docs/feature/fix-db-credentials-from-sops/rca.md
+++ b/docs/feature/fix-db-credentials-from-sops/rca.md
@@ -509,7 +509,7 @@ no signature change:
 - `src/user_action.rs:24-25` — same pair
 
 Add a private helper in `src/config_parse.rs`, e.g.
-`fn splice_db_password(base_url: &str) -> Result<String, Box<dyn std::error::Error>>`,
+`fn inject_db_password(base_url: &str) -> Result<String, Box<dyn std::error::Error>>`,
 and call it in the `postgres` arm only. It must:
 
 0. **de-quote the base URL first** — `clean_string_from_quotes` (`src/helpers.rs:46`),
@@ -660,7 +660,7 @@ Ordered by expected damage.
 **R-1 — The live INI still contains the password, and it is outside this commit's
 reach. HIGH.**
 `~/.config/rusty-cv-creator/rusty-cv-config.ini` currently holds
-`postgres://rusty_cv:<pw>@nixos-02…/rusty_cv`. After the fix, `splice_db_password`
+`postgres://rusty_cv:<pw>@nixos-02…/rusty_cv`. After the fix, `inject_db_password`
 receives that string as its "base". Naive insertion yields
 `postgres://rusty_cv:<old>:<new>@nixos-02…` — malformed, and the failure mode is a
 confusing parse/auth error rather than the intended actionable message.

--- a/docs/feature/fix-db-credentials-from-sops/rca.md
+++ b/docs/feature/fix-db-credentials-from-sops/rca.md
@@ -1,0 +1,805 @@
+# RCA — plaintext Postgres password in the tracked tree + three-way host/database drift
+
+- **Analyst**: Rex (root cause analysis), Toyota 5 Whys, depth 5, multi-causal
+- **Date**: 2026-07-30
+- **Repo / branch**: `rusty_cv_creator` @ `feat/l74-db-creds`
+  (worktree `/home/seventh/src/claude-worktrees/rusty_cv_creator/l74-db-creds`)
+- **Configuration**: `investigation_depth: 5`, `multi_causal: true`, `evidence_required: true`
+
+---
+
+## 1. Scope and problem statement
+
+Two faults, one investigation pass.
+
+**Fault (a) — credential exposure.** A plaintext PostgreSQL password (`REDACTED-SEE-SOPS`,
+user `rusty_cv`) is committed in the tracked tree at two sites carrying the identical
+literal:
+
+- `devenv.nix:25` — `env.DATABASE_URL = "postgres://rusty_cv:REDACTED-SEE-SOPS@nixos-03.caracara-palermo.ts.net/db_rusty_cv"`
+- `rusty-cv-config-example.ini:64` — `db_pg_host = "postgres://rusty_cv:REDACTED-SEE-SOPS@nixos-01.caracara-palermo.ts.net/db_rusty_cv"`
+
+**Fault (b) — configuration drift.** The `(host, database)` pair exists in three
+copies that disagree:
+
+| Copy | Host | Database | Tracked? |
+| --- | --- | --- | --- |
+| `devenv.nix:25` | `nixos-03` | `db_rusty_cv` | yes |
+| `rusty-cv-config-example.ini:64` | `nixos-01` | `db_rusty_cv` | yes |
+| `~/.config/rusty-cv-creator/rusty-cv-config.ini` (live) | `nixos-02` | `rusty_cv` | no (outside repo; taken as given, not read) |
+
+**In scope**: credential handling and DB-target resolution in this repo, its
+pre-commit hook set, its architecture claims, and its tracked test fixtures.
+
+**Out of scope**: the live INI file's contents (given, not inspected), the parallel
+nixos-02 database-recreation lane, secret rotation on the Postgres server itself.
+
+**Impact classification** (per investigation-techniques): *Operational → config drift*
+compounded by *System failure → security/access controls*. Severity is bounded by the
+repo being private and the host being Tailscale-only, but the password is in git
+history and must be treated as burned regardless of the fix.
+
+---
+
+## 2. Timeline (evidence-backed)
+
+| Date | Commit | Event | Evidence |
+| --- | --- | --- | --- |
+| 2024-07-28 | `53ceda1` | Password literal enters the tracked tree via `rusty-cv-config-example.ini:64`, host `nixos-01`, db `db_rusty_cv`. | `git blame -L 64,64 rusty-cv-config-example.ini` → `53ceda14 (Chess7th 2024-07-28)` |
+| 2025-08-19 | `fef6db6` | Second copy of the same literal enters `devenv.nix`, already pointing at a *different* host (`nixos-03`). Drift begins here. | `git show fef6db6:devenv.nix \| grep DATABASE_URL` → line 9, `…@nixos-03…/db_rusty_cv` |
+| 2026-02-12 | `29bfaf5` | `devenv.nix:25` reformatted (nixfmt/treefmt), literal unchanged. | `git blame -L 25,25 devenv.nix` |
+| (undated) | — | Live INI moves to `nixos-02` / `rusty_cv`. Neither tracked copy follows. | Given by the maintainer |
+| 2026-07-30 | — | Fault detected. Neither tracked copy has ever been reconciled: `git log -S'REDACTED-SEE-SOPS'` returns exactly 3 commits across ~2 years. | `git log -S'REDACTED-SEE-SOPS' --all` |
+
+Elapsed exposure: **~24 months** for the INI copy, **~11 months** for the devenv copy.
+
+---
+
+## 3. Hypothesis verdict (asked explicitly)
+
+> **Hypothesis**: `check_if_db_env_is_set_or_set_from_config` prefers an already-set
+> `DATABASE_URL` over the INI value; because `devenv.nix` exports `DATABASE_URL` into
+> every dev shell, the hardcoded URL silently wins there, so nobody ever exercised the
+> INI value and the three copies drifted apart unnoticed.
+
+### Verdict: **PARTLY RIGHT — correct about the precedence inside that one function, wrong about its consequence, and it points at the wrong engine.**
+
+At a glance, before the detail:
+
+| Hypothesis claim | Verdict | Evidence |
+| --- | --- | --- |
+| `check_if_db_env_is_set_or_set_from_config` prefers a set `DATABASE_URL` over the INI | **TRUE** | `src/helpers.rs:86-92` |
+| That preference decides which URL the postgres connection uses | **FALSE** | `src/config_parse.rs:76-81` reads the INI unconditionally; no `std::env::var` on the postgres arm. `src/main.rs:39` discards the function's result |
+| `devenv.nix:25` therefore silently wins in the dev shell | **FALSE for postgres, TRUE for sqlite** | `src/config_parse.rs:83-86` — the *sqlite* arm is env-first, so the exported `postgres://` URL wins there and is fed to `SqliteConnection::establish` (E-1) |
+| That is why the INI was never exercised and the copies drifted | **FALSE — right conclusion, wrong mechanism** | The INI *is* the authoritative postgres source. The tracked copies drifted because neither is ever read: `src/cli_structure.rs:29` points at the untracked live INI (Root Cause B) |
+
+**What is confirmed.** The precedence claim is literally true of that function.
+`src/helpers.rs:86-92`:
+
+```rust
+if let Ok(val) = std::env::var("DATABASE_URL") {
+    drop(val);
+} else {
+    let db_url = ctx.get_user_input_db_url()?;
+    std::env::set_var("DATABASE_URL", db_url);
+    info!("Fetched the DATABASE_URL env variable");
+}
+```
+
+Env-set wins; INI is the fallback. Confirmed.
+
+**What is refuted.** That precedence has **no effect on the Postgres connection**, for
+two independent reasons:
+
+1. **The function's result is discarded and its only output is a process env var.**
+   `src/main.rs:39` — `let _ = check_if_db_env_is_set_or_set_from_config(&ctx);`. It
+   returns a Tailscale status string (`src/helpers.rs:94-107`), thrown away. Its sole
+   lasting effect is mutating `DATABASE_URL` in the process environment.
+2. **Nothing on the Postgres connect path reads `DATABASE_URL`.** The single resolution
+   point is `resolve_db_target`, `src/config_parse.rs:72-91`:
+
+```rust
+match engine.trim() {
+    "postgres" => {
+        let url = ctx.get_user_input_db_url()      // INI [db] db_pg_host — unconditional
+            .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+        Ok((engine, url))
+    }
+    "sqlite" => {
+        let url = match std::env::var("DATABASE_URL") {   // env FIRST, INI fallback
+            Ok(value) => fix_home_directory_path(&value),
+            Err(_) => format!("sqlite://{}", get_db_configurations(ctx)?),
+        };
+        Ok((engine, url))
+    }
+    _ => Ok((engine, String::new())),
+}
+```
+
+The `postgres` arm (`src/config_parse.rs:76-81`) reads `ctx.get_user_input_db_url()`
+→ `src/global_conf.rs:141-145` → `self.config.get("db", "db_pg_host")` — the INI value,
+unconditionally, with **no** `std::env::var` call. All three connect sites route through
+it: `src/cli_structure.rs:150-151`, `src/cv_insert.rs:32-33`, `src/user_action.rs:24-25`,
+each calling `rusty_cv_creator::database::establish_connection(&engine, &url)`
+(`src/database.rs:19-28`).
+
+**Therefore, on the Postgres path the INI always wins and `devenv.nix:25` never reaches
+`PgConnection::establish`.** The precedence is the *opposite* of the hypothesis.
+
+**Where the env-wins precedence is real — and harmful.** It is the **sqlite** arm,
+`src/config_parse.rs:83-86`, that prefers `DATABASE_URL`. `devenv.nix:25` exports a
+`postgres://` URL into every dev shell, so a sqlite-engine run *inside the dev shell*
+hands `postgres://rusty_cv:REDACTED-SEE-SOPS@nixos-03…/db_rusty_cv` to
+`SqliteConnection::establish` (`src/database.rs:25`), which treats it as a filename.
+This is a live latent defect created by the same line, and it is why removing
+`devenv.nix:25` is a fix rather than a cosmetic change.
+
+**Corrected causal claim for the drift.** The tracked copies drifted not because the env
+shadowed the INI, but because **the only copy the program ever reads at runtime is the
+untracked live INI** (`src/cli_structure.rs:29` defaults `--config-ini` to
+`~/.config/rusty-cv-creator/rusty-cv-config.ini`). Both tracked copies are unexecuted
+documentation: `rusty-cv-config-example.ini` is never loaded by any code path or test,
+and `devenv.nix:25` is dead for postgres. Nothing — no test, no CI job, no startup
+assertion — ever compares them to the live value, so they were free to rot.
+
+A further finding surfaced during this pass reinforces that conclusion: the postgres arm
+may never have been reachable at all, because quoted INI values are not stripped on the
+DB accessor path (contributing factor **E-3**, risk **R-10**). If the live INI quotes its
+values as the tracked example does, `resolve_db_target` has been falling through to its
+`_` arm (`src/config_parse.rs:89`) for the entire life of the postgres feature.
+
+### Alternatives considered and rejected
+
+Competing explanations tested before settling on the four branches below.
+
+| Alternative | Rejected because |
+| --- | --- |
+| **Merge conflict / bad resolution** left two divergent copies | The divergence was introduced by a single clean commit, not a merge: `fef6db6` (2025-08-19) *added* `env.DATABASE_URL` to `devenv.nix` already pointing at `nixos-03` while the INI said `nixos-01`. `git log -S'REDACTED-SEE-SOPS' --all` returns 3 commits total, none a merge. A `check-merge-conflicts` hook is also enabled (`devenv.nix:95-99`). |
+| **Password rotation** desynchronised the copies | Both tracked copies carry the **identical** literal `REDACTED-SEE-SOPS`; only the host and database differ. A rotation would have produced differing passwords, not differing hosts. |
+| **A CI job or generator** was meant to reconcile the copies and broke | No such job exists and none ever did: `grep -niE "database\|postgres\|DATABASE_URL" .github/workflows/` matches only GitHub/Codecov token lines across `build.yml`, `rust-tests.yml`, `release.yml`. No generator, template, or import links the three files. |
+| **The example INI is a deliberate decoy** with fake values | The credential is real (maintainer-confirmed), and the file is presented as a working configuration (`rusty-cv-config-example.ini:57` sets `engine = "postgres"`, not a placeholder). Genuinely optional fields in the same file are commented out (`:16`, `:22`, `:28`, `:46`, `:53`) — this one is not. |
+| **The hooks were disabled or bypassed** (`--no-verify`) for the offending commits | Not needed as an explanation: the hooks are enabled (`devenv.nix:101-111`) and *structurally cannot match* a URL userinfo password (Branch C). Bypass is unnecessary to explain the outcome, so it is not invoked. |
+
+---
+
+## 4. Root cause chain (Toyota 5 Whys, multi-causal)
+
+Four independent branches. Each WHY carries a `file:line` citation.
+
+### Branch A — a plaintext password sits in the tracked tree
+
+```
+WHY 1A: A working Postgres password is readable in the tracked tree at two sites.
+  [Evidence: git grep -n "REDACTED-SEE-SOPS" -> devenv.nix:25, rusty-cv-config-example.ini:64;
+   both are tracked (git ls-files) and both carry the identical literal]
+
+WHY 2A: The config format has one field for the whole connection URL, so the secret
+        is structurally inseparable from the non-secret host/database.
+  [Evidence: src/global_conf.rs:141-145 - get_user_input_db_url() returns the whole
+   `db_pg_host` string; src/config_parse.rs:76-81 passes it verbatim to the caller;
+   src/database.rs:24 hands it verbatim to PgConnection::establish. There is no
+   second field and no assembly step anywhere in the path]
+
+WHY 3A: The example file is a full working config rather than a template, so the only
+        way to make it "correct" was to paste the real, complete URL.
+  [Evidence: rusty-cv-config-example.ini:57 `engine = "postgres"` (not sqlite) and
+   :64 a complete credentialed URL, versus :16/:22/:28/:46/:53 where genuinely optional
+   fields are commented-out placeholders. The file demonstrates the real deployment,
+   not a fill-in-the-blanks skeleton]
+
+WHY 4A: No secret-injection seam was ever designed. Every other externally-supplied
+        secret in this codebase was given an env-only rule; the DB password was not.
+  [Evidence: rusty-cv-config-example.ini:19-21 - "For token auth the token is read
+   ONLY from the GITHUB_TOKEN environment variable - never from this INI file, the git
+   command line, or the cached clone." The rule exists, is documented, and is enforced
+   for GITHUB_TOKEN (ADR-0008 / docs/product/architecture/brief.md:189) - and was simply
+   not applied to `db_pg_host`, which predates it by 2 years (53ceda1, 2024-07-28)]
+
+WHY 5A: Postgres support (53ceda1, 2024-07-28) was added as a single-user convenience
+        against a Tailscale-only host, so the URL was treated as a connection detail
+        rather than a credential, and no threat model made the distinction.
+  [Evidence: docs/product/architecture/brief.md:175 - "Security - single-user local
+   tool; Postgres reached only over Tailscale". The stated control is network
+   reachability; secrecy of the credential is never listed as a control]
+
+-> ROOT CAUSE A: The connection URL was modelled as a single opaque configuration
+   string with no secret/non-secret split, because the security model relied entirely
+   on network reachability (Tailscale) and never treated the DB password as a secret
+   requiring an injection seam - even after the same repo established exactly that
+   seam for GITHUB_TOKEN.
+```
+
+### Branch B — three copies of `(host, database)` that disagree
+
+```
+WHY 1B: devenv.nix says nixos-03/db_rusty_cv, the example INI says nixos-01/
+        db_rusty_cv, the live INI says nixos-02/rusty_cv.
+  [Evidence: devenv.nix:25; rusty-cv-config-example.ini:64; live value given by
+   the maintainer]
+
+WHY 2B: Neither tracked copy is ever read by the running program on the postgres path,
+        so neither can be wrong in any way a user would notice.
+  [Evidence: src/cli_structure.rs:29 defaults --config-ini to
+   "~/.config/rusty-cv-creator/rusty-cv-config.ini" - the LIVE file, not the example;
+   src/config_parse.rs:76-81 reads `db_pg_host` from THAT file. devenv.nix:25's
+   DATABASE_URL is never consulted on the postgres arm (see section 3).
+   git grep "rusty-cv-config-example" over src/ and tests/ returns no hits - the
+   example file is loaded by nothing]
+
+WHY 3B: There is no single source of truth and no cross-copy consistency check -
+        not in code, not in tests, not in CI.
+  [Evidence: the three values live in three unrelated formats (Nix attr, INI key,
+   user-local INI key) with no generator, no import, no shared constant.
+   .github/workflows/rust-tests.yml, build.yml, release.yml contain no DB config
+   step: `grep -niE "database|postgres|DATABASE_URL" .github/workflows/` returns
+   only GitHub/Codecov token lines]
+
+WHY 4B: Config was designed as "documentation you copy once", so drift between the
+        documented value and the operated value was never modelled as a failure mode.
+  [Evidence: README.md:164-171 instructs the user to hand-write a DATABASE_URL into
+   a .env - a fourth, parallel, hand-maintained copy. The docs actively multiply
+   copies instead of collapsing them]
+
+WHY 5B: The tracked copies are unexecuted artifacts. Nothing in the build, the test
+        suite, or the runtime ever forces them to agree with reality, so entropy is
+        the default state and 24 months of drift produced zero signal.
+  [Evidence: git log -S'REDACTED-SEE-SOPS' --all returns exactly 3 commits (53ceda1
+   2024-07-28, 7fd245e 2024-12-20, fef6db6 2025-08-19) - the value was never
+   corrected, only copied. The host diverged at fef6db6 (nixos-03 vs the INI's
+   nixos-01) and no build, test, or hook noticed for 11 months]
+
+-> ROOT CAUSE B: Configuration exists as three hand-maintained, mutually unaware
+   copies, of which only the untracked one is ever executed; there is no source of
+   truth, no generator, and no consistency assertion, so the tracked copies decay
+   silently and unobservably.
+```
+
+### Branch C — the pre-commit hook set could never have caught this
+
+```
+WHY 1C: Two enabled secret-detection hooks let a credentialed URL through, twice.
+  [Evidence: devenv.nix:101-111 enables detect-aws-credentials and
+   detect-private-keys at stage pre-commit; the literal landed anyway at 53ceda1
+   and fef6db6]
+
+WHY 2C: Neither hook has any notion of a URL userinfo password. This is structural,
+        not a tuning gap.
+  [Evidence: pre_commit_hooks/detect_private_key.py - BLACKLIST is a fixed list of
+   10 PEM/PuTTY header byte-strings ('BEGIN RSA PRIVATE KEY', 'BEGIN OPENSSH PRIVATE
+   KEY', ...) substring-matched against file bytes. "postgres://user:pass@host"
+   matches none of them, and no pattern in the list is a regex.
+   pre_commit_hooks/detect_aws_credentials.py - main() builds its key set ONLY from
+   ~/.aws/config, ~/.aws/credentials, /etc/boto.cfg, ~/.boto and the AWS_SECRET_ACCESS_KEY
+   / AWS_SECURITY_TOKEN / AWS_SESSION_TOKEN env vars, then substring-matches those exact
+   values (check_file_for_aws_keys). It cannot flag a string that is not already one of
+   the developer's own AWS secrets. Source:
+   /nix/store/xw778bvafgfszj2vsn0zj2qdyl06pmwg-python3.13-pre-commit-hooks-6.0.0/
+   lib/python3.13/site-packages/pre_commit_hooks/]
+
+WHY 3C: The hook set has no generic, pattern- or entropy-based secret scanner at all.
+        Its 11 hooks are formatters, whitespace/EOL fixers, a merge-conflict check, a
+        shell linter, a markdown linter, and commit-message tooling.
+  [Evidence: devenv.nix:78-197 - the complete git-hooks.hooks set:
+   rusty-commit-saver, check-merge-conflicts, detect-aws-credentials,
+   detect-private-keys, end-of-file-fixer, mixed-line-endings,
+   trim-trailing-whitespace, shellcheck, mdsh, treefmt, commitizen, gitlint,
+   markdownlint. No gitleaks, ripsecrets, trufflehog, or equivalent]
+
+WHY 4C: The two security-shaped hook names were taken as coverage. Their presence,
+        not their matching behaviour, is what got written down as the control.
+  [Evidence: docs/product/architecture/brief.md:176 - "no secrets in repo (pre-commit
+   hooks for keys/AWS creds in devenv)". The claim cites the hooks by name as the
+   evidence for the property. Nobody read what they match]
+
+WHY 5C: The hooks were adopted as a stock bundle rather than derived from this
+        repo's own threat surface, and no adversarial test ("commit a fake secret,
+        does it block?") was ever run against them.
+  [Evidence: the hook block was never revised after the credential landed - the two
+   detect-* hooks at devenv.nix:101-111 sit unchanged alongside the very literal at
+   devenv.nix:25, in the same file, 76 lines apart. A hook set derived from this
+   repo's surface would have been tested against its own content]
+
+-> ROOT CAUSE C: The secret-detection control was selected by name rather than by
+   matched pattern, was never adversarially tested against a planted secret, and
+   contains no generic credential scanner - so the repo has had zero real protection
+   against a credential literal for its entire life.
+
+   Named gap: NO GENERIC SECRET SCANNER. detect-private-keys = fixed PEM header
+   allowlist (URL userinfo unmatchable). detect-aws-credentials = matches only the
+   committing developer's own pre-existing AWS secret values (URL userinfo
+   unmatchable). Neither is a pattern scanner. No CI-side equivalent either.
+
+   Secondary defect in the same hook: detect_aws_credentials.main() returns 2
+   ("No AWS keys were found...") when no ~/.aws file and no AWS_* env var exist, and
+   devenv.nix:101-105 does not pass --allow-missing-credentials. On any machine or CI
+   runner without AWS credentials the hook is a hard failure, not a scan - so it has
+   never contributed protection under any configuration.
+```
+
+### Branch D — the architecture brief asserts a property that is false
+
+```
+WHY 1D: docs/product/architecture/brief.md:176 states "no secrets in repo (pre-commit
+        hooks for keys/AWS creds in devenv)". Both halves are wrong: there IS a secret
+        in the repo, and the cited hooks cannot detect it.
+  [Evidence: brief.md:175-176 verbatim, under "Quality attributes (ISO 25010,
+   realized)" - the section header asserts these are REALIZED, not aspirational.
+   Contradicted by devenv.nix:25 and rusty-cv-config-example.ini:64, and by Branch C]
+
+WHY 2D: The claim was written by reading the devenv hook names, not by scanning the
+        tree or testing the hooks.
+  [Evidence: the parenthetical "(pre-commit hooks for keys/AWS creds in devenv)"
+   names exactly the two hooks at devenv.nix:101-111 - it is a restatement of the
+   config, offered as evidence of the outcome]
+
+WHY 3D: The brief documents intended properties as realized ones, with no
+        verification step between claim and publication.
+  [Evidence: brief.md:166 heading "Quality attributes (ISO 25010, realized)".
+   The four sibling claims at :168-174 (Maintainability, Portability, Reliability,
+   Functional suitability) all cite a measurement or an ADR - "line coverage
+   54% -> 84% (ADR-0005)", "(ADR-0004)". The Security claim at :175-176 is the only
+   one citing neither a measurement nor an ADR]
+
+WHY 4D: There is no ADR and no owner for security, so no artifact was obliged to
+        justify the claim.
+  [Evidence: brief.md:180-189 Decisions table, D-1..D-8: build, subprocess port,
+   persistence, tool checks, coverage, AppContext, CI gates, template sourcing.
+   No security ADR. docs/product/architecture/ contains adr-0003..adr-0008 plus
+   adr-0006-inject-appcontext - none security-scoped]
+
+WHY 5D: The security posture was assumed from context ("single-user local tool,
+        Tailscale-only") rather than analysed, so a documentation claim became the
+        only artifact standing in for a control - and once written, it discouraged
+        anyone from looking again.
+  [Evidence: brief.md:175 - "single-user local tool; Postgres reached only over
+   Tailscale" is a context statement used directly as a security conclusion.
+   docs/feature/config-injection/feature-delta.md:107 shows the ONE place the
+   DATABASE_URL side channel was noticed - flagged as an "Open question" about
+   coupling and testability, never as a secrets question]
+
+-> ROOT CAUSE D: An unverified documentation claim was recorded as a realized quality
+   attribute, substituting for the control it described - which both hid the exposure
+   and removed the incentive to re-examine it.
+```
+
+---
+
+## 5. Backwards chain validation
+
+Each root cause traced forward: *if this existed, would it produce the observed symptoms?*
+
+| Root cause | Forward trace | Produces symptom? |
+| --- | --- | --- |
+| A (no secret/non-secret split in the URL field) | One field must hold everything → an example file that demonstrates a real deployment must contain the password → literal is committed | **Yes** — fault (a), both sites |
+| B (three unaware copies, only the untracked one executed) | A tracked copy can hold any value with zero runtime, test, or CI consequence → values diverge whenever any one is edited → three-way disagreement | **Yes** — fault (b); explains 11 months of nixos-01/nixos-03 divergence with no signal |
+| C (no generic secret scanner) | A credentialed URL is committed and no hook matches it → commit succeeds → literal persists | **Yes** — explains why (a) landed twice, at `53ceda1` and `fef6db6` |
+| D (unverified "no secrets" claim) | Written control substitutes for real control → no audit is triggered → exposure persists across 2 years and multiple architecture reviews | **Yes** — explains duration, not initial occurrence |
+
+**Cross-validation, no contradictions:**
+
+- A + B are orthogonal and compose: A explains *why a secret was in the file*, B explains *why the file's other values were wrong and stayed wrong*. Neither requires the other; both are needed to explain the full defect.
+- C is independent of A and B: it explains *why nothing stopped the commit*, and applies to both sites equally.
+- D depends on C (the claim cites the hooks) but is not implied by it: the hooks could have been weak *and* the brief honest. D adds the duration factor.
+- **Refuted hypothesis is consistent with all four**: the hypothesised env-shadowing mechanism is not needed to explain any symptom. B fully explains the drift by non-execution. The env precedence that *does* exist (sqlite arm, `src/config_parse.rs:83`) explains a *different*, previously unreported latent defect (see contributing factor E-1) — no contradiction, an addition.
+
+**Completeness check** — asked at every level. One additional branch surfaced and is
+recorded as contributing factor E-2 (secret leaked into the environment of every
+spawned subprocess). It is a consequence of A, not a fifth root cause. No further
+branches found.
+
+**All symptoms explained: yes.** Password in tree (A + C), two copies of it (C),
+three-way host/db disagreement (B), 24-month persistence (D), plus one latent defect
+found during the pass (E-1).
+
+---
+
+## 6. Contributing factors
+
+**E-1 — Precedence is inverted between engines, and the exported URL poisons the
+sqlite path.** `resolve_db_target` is INI-only for `postgres`
+(`src/config_parse.rs:76-81`) but env-first for `sqlite` (`src/config_parse.rs:83-86`),
+while `check_if_db_env_is_set_or_set_from_config` is env-first for *both*
+(`src/helpers.rs:86-92`, `:118-124`). Three functions, two rules, one env var. Concrete
+consequence: inside the dev shell, `devenv.nix:25` exports a `postgres://` URL that the
+sqlite arm prefers, so `SqliteConnection::establish("postgres://rusty_cv:…@nixos-03…")`
+(`src/database.rs:25`) is attempted and the URL is interpreted as a filename. This is a
+live defect today, independent of the credential issue.
+
+**E-2 — The secret is written into the process environment and inherited by every
+subprocess.** `src/helpers.rs:90` — `std::env::set_var("DATABASE_URL", db_url)` — runs
+before `SystemRunner` spawns `sudo tailscale` (`src/main.rs:107`), `just`/`tectonic`
+(`src/main.rs:96`), and `zathura` (`src/main.rs:58`). `std::process::Command` inherits
+the parent environment by default, so the credential is visible in each child's
+environment. **The fix must not reuse this mechanism.**
+
+**E-3 — The postgres arm is very likely dead on arrival: quoted INI values are never
+stripped on this path.** `configparser` returns values **with** their surrounding
+quotes — asserted by the repo's own test, `src/config_parse.rs:116-120`:
+`load_config("[section]\nkey = \"value\"")` then
+`assert_eq!(ini.get("section","key").unwrap(), "\"value\"")`. Every other config read
+compensates by calling `clean_string_from_quotes`: `src/config_parse.rs:50`
+(`get_variable_from_config_file`), `:58-59` (`get_db_configurations`),
+`src/file_handlers.rs:379`. **The two DB accessors do not**:
+`src/global_conf.rs:137-139` (`get_user_input_db_engine`) and `:141-145`
+(`get_user_input_db_url`) return the raw value.
+
+Consequences, if the live INI quotes its values the way the tracked example does
+(`rusty-cv-config-example.ini:57` `engine = "postgres"`, `:64` `db_pg_host = "postgres://…"`):
+
+- `src/config_parse.rs:75` matches `engine.trim()` against the literal `postgres`, but
+  the value is `"postgres"` *including the quote characters* → no arm matches → the
+  `_` fallthrough at `:89` returns `(engine, String::new())` → `establish_connection`
+  (`src/database.rs:26`) errors with `Unknown DB engine: "postgres"`.
+- `src/helpers.rs:82` — `engine.is_ok_and(|e| "postgres" == e)` — fails the same way and
+  takes the *else* (sqlite) branch even when the engine is postgres.
+- Even if the engine matched, the URL handed to `PgConnection::establish`
+  (`src/database.rs:24`) would still carry literal `"` characters.
+
+This is a **conditional finding**: it holds iff the live INI quotes its values. It is
+cheap for the maintainer to check and it materially strengthens Root Cause B — if true,
+the postgres path has never successfully connected through `resolve_db_target`, which is
+the most complete possible explanation for why the tracked copies were free to rot. It
+also directly affects the fix: the base URL must be de-quoted **before** the password is
+spliced, or the password lands inside a quoted string (§8 R-10).
+
+**F — The hook gap (Branch C), named.** No generic secret scanner in
+`devenv.nix:78-197`; the two `detect-*` hooks are structurally incapable of matching URL
+userinfo; `detect-aws-credentials` additionally hard-fails (exit 2) wherever no `~/.aws`
+exists because `--allow-missing-credentials` is not passed (`devenv.nix:101-105`).
+
+**G — The env-wins precedence (hypothesis, corrected).** Real at `src/helpers.rs:86` and
+`src/config_parse.rs:83`; **not** on the postgres connect path. Listed as a contributing
+factor to E-1 and to the general confusion about which value is authoritative — not as
+the cause of the drift.
+
+**H — Errors are discarded at three of the relevant call sites.**
+`src/main.rs:39` (`let _ = check_if_db_env_…`), `src/cli_structure.rs:128`
+(`let _ = remove_cv(ctx, &filters)`), and `src/cv_insert.rs:29-42` (DB failure
+downgraded to `warn!`). This is a *pre-existing* obstacle to the decided fix's
+"fail loudly" requirement — see §7.4 and §8 R-3.
+
+**I — Docs multiply copies.** `README.md:164-171` tells the user to hand-write a
+`DATABASE_URL` (including a credentialed `postgresql://user:password@localhost/cv_db`
+example at `:171`) into a `.env`, creating a fourth parallel copy — and, for postgres,
+one the program never reads.
+
+**J — A credential-shaped literal also sits in a tracked test fixture.**
+`tests/integration-tests.rs:44` — `db_pg_host = "postgresql://test:test@localhost/test"`.
+Not a real secret, but it is the exact shape any future scanner must flag, so it must be
+cleaned or the scanner will need an allowlist on day one.
+
+---
+
+## 7. Precise code changes required by the decided fix shape
+
+Decided shape (not re-litigated here): INI keeps host + database as a **passwordless**
+Postgres URL reconciled onto **`nixos-02` / `rusty_cv`**; the password comes from
+**`RUSTY_CV_DB_PASSWORD`** (sops via home-manager on the real machine, gitignored `.env`
+in dev) and is spliced in **immediately before connecting**; missing/empty
+`RUSTY_CV_DB_PASSWORD` on the postgres path **fails loudly** and never falls back to a
+passwordless connect; the **sqlite path is unaffected**.
+
+### 7.1 Tracked files still holding a credential literal or a stale host/database
+
+Complete list. `git grep -n "REDACTED-SEE-SOPS"` plus the credential-shaped and
+stale-target scan below is exhaustive over tracked files.
+
+| # | File:line | Current content | Required change |
+| --- | --- | --- | --- |
+| 1 | `devenv.nix:25` | `env.DATABASE_URL = "postgres://rusty_cv:REDACTED-SEE-SOPS@nixos-03…/db_rusty_cv";` | **Delete the line.** It is dead for postgres (§3) and actively poisons the sqlite arm (E-1). See R-4 for the `diesel-cli` consequence. |
+| 2 | `rusty-cv-config-example.ini:64` | `db_pg_host = "postgres://rusty_cv:REDACTED-SEE-SOPS@nixos-01…/db_rusty_cv"` | **Replace with the passwordless, reconciled URL**: `postgres://rusty_cv@nixos-02.caracara-palermo.ts.net/rusty_cv`. Add a comment above it stating the password is read **only** from `RUSTY_CV_DB_PASSWORD` and must never be written here — mirroring the existing `GITHUB_TOKEN` rule at `rusty-cv-config-example.ini:19-21`. |
+| 3 | `README.md:171` | `echo "DATABASE_URL=postgresql://user:password@localhost/cv_db" > .env` | **Rewrite.** Credential-shaped, and now wrong guidance: `DATABASE_URL` is not read on the postgres path. Replace with: set `[db] db_pg_host` to the passwordless URL, and supply `RUSTY_CV_DB_PASSWORD` via sops/home-manager (real) or a gitignored `.env` (dev). |
+| 4 | `README.md:168` | `echo "DATABASE_URL=sqlite://…/applications.db" > .env` | **Keep** (sqlite path is genuinely env-first, `src/config_parse.rs:83`), but move it under an explicit "sqlite only" heading so it is not read as postgres guidance. |
+| 5 | `README.md:174-178` | `diesel setup` / `diesel migration run` | **Add a note**: `diesel-cli` reads `DATABASE_URL` from the environment; with `devenv.nix:25` removed it must be supplied inline or from `.env` (see R-4). |
+| 6 | `env.sample:1` | `DATABASE_URL=sqlite://$HOME/.config/rusty-cv-creator/applications.db` | **Keep**, and **add a commented line** `# RUSTY_CV_DB_PASSWORD=` with a note that an empty value is rejected (do not ship an uncommented empty assignment — that is exactly the failure case the fix must reject). |
+| 7 | `tests/integration-tests.rs:44` | `db_pg_host = "postgresql://test:test@localhost/test"` | **Change to passwordless** `postgresql://test@localhost/test`. Required so the new scanner test (§8.1) needs no allowlist. The fixture drives a sqlite-engine test (`engine = "sqlite"` at `:43`), so `db_pg_host` is never resolved — the change is inert. |
+| 8 | `tests/tui_job_applications_scenarios.rs:31` | `db_pg_host = \"postgres://placeholder\"` | **No change** — already passwordless and scanner-clean. Verify it stays that way. |
+| 9 | `docs/product/architecture/brief.md:175-176` | "Security — single-user local tool; Postgres reached only over Tailscale; **no secrets in repo (pre-commit hooks for keys/AWS creds in devenv)**" | **False as written — must be rewritten** (Branch D). Replace with the realized state: DB password injected from the environment (`RUSTY_CV_DB_PASSWORD`, sops/home-manager), never in the repo or the INI; enforced by a tracked-tree credential scan in the test suite/CI; historical exposure noted with rotation status. Do not re-cite `detect-aws-credentials`/`detect-private-keys` as the control — they do not provide it. |
+| 10 | *(out of tree)* `~/.config/rusty-cv-creator/rusty-cv-config.ini` | live: `nixos-02` / `rusty_cv`, password present | **Maintainer action, manual.** Strip the password from `db_pg_host`, leave host+db. Not reachable from this commit — the single largest breakage risk (§8 R-1). |
+
+### 7.2 Exact call sites that must change
+
+**`src/config_parse.rs:72-91` — `resolve_db_target`, the single choke point.**
+The `postgres` arm at `:76-81` is the only place the postgres URL is produced, and all
+three connects consume it. Splice here and every call site inherits the behaviour with
+no signature change:
+
+- `src/cli_structure.rs:150-151` — `let (engine, url) = resolve_db_target(ctx)?;` → `establish_connection(&engine, &url)?`
+- `src/cv_insert.rs:32-33` — same pair, inside the lazy `open_conn` closure
+- `src/user_action.rs:24-25` — same pair
+
+Add a private helper in `src/config_parse.rs`, e.g.
+`fn splice_db_password(base_url: &str) -> Result<String, Box<dyn std::error::Error>>`,
+and call it in the `postgres` arm only. It must:
+
+0. **de-quote the base URL first** — `clean_string_from_quotes` (`src/helpers.rs:46`),
+   as every other config reader already does (E-3). Best applied inside
+   `get_user_input_db_url` (`src/global_conf.rs:141-145`) together with the same
+   treatment for `get_user_input_db_engine` (`:137-139`), so the engine `match` at
+   `src/config_parse.rs:75` and the comparison at `src/helpers.rs:82` can succeed at all;
+1. read `RUSTY_CV_DB_PASSWORD`; on `Err`, on empty, or on whitespace-only → return `Err`
+   with a message naming the variable, both supply routes (sops/home-manager, gitignored
+   `.env`), and the config file it applies to;
+2. **percent-encode** the password before insertion (see §8 R-6);
+3. insert it into the userinfo of `base_url` after the username;
+4. **reject a `base_url` that already carries a password** (`user:pass@`) with a distinct
+   error — otherwise a stale live INI yields `postgres://rusty_cv:OLD:NEW@host`
+   (§8 R-1);
+5. **never** return `base_url` unchanged on any error path — no passwordless fallback;
+6. **never** call `std::env::set_var` (E-2).
+
+**`src/config_parse.rs:83-86` — the `sqlite` arm: do not touch.** Its `DATABASE_URL`-first
+behaviour is depended on by `tests/integration-tests.rs:78`,
+`tests/tui_job_applications_scenarios.rs:62`, `:86`, `:111`, and the feature specs at
+`tests/tui_job_applications/walking_skeleton.feature:18,24-26` and
+`milestone_1_table_display.feature:23,58-59`.
+
+**`src/helpers.rs:77-126` — `check_if_db_env_is_set_or_set_from_config`.**
+The postgres arm's env block at `:86-92` must be **removed**: it has no consumer (§3)
+and, once a password exists, would export it to every subprocess (E-2). Keep
+`ensure_tools_available(&["sudo","tailscale"])` at `:84` and the Tailscale probe at
+`:94-107`. The sqlite arm at `:118-124` is unchanged. Update the doc comment at
+`src/config_parse.rs:66-71`, which currently documents the old mirror relationship.
+
+**`src/global_conf.rs:141-145` — `get_user_input_db_url`.** Now returns a *passwordless
+base* URL. Two required edits:
+- the error string is wrong today — `"Could not get the database engine"` for a missing
+  `db_pg_host` (`:144`). Make it name `[db] db_pg_host` and the config file path.
+- rename to something like `get_db_base_url` so no caller mistakes it for a
+  ready-to-connect URL. Callers: `src/config_parse.rs:77`, `src/helpers.rs:89` (the
+  latter disappears with the change above).
+
+**`src/database.rs:19-28` — `establish_connection`: unchanged.** It receives a resolved
+`(engine, url)` and stays config-free, per ADR-0006 (`docs/product/architecture/adr-0006-inject-appcontext.md:60`)
+and D-5 (`docs/feature/config-injection/feature-delta.md:24`). Do not move splicing here.
+
+**Loudness plumbing — three sites that currently swallow the error** (contributing
+factor H). `resolve_db_target` returning `Err` is necessary but not sufficient:
+
+| Site | Today | Effect on a missing-password error |
+| --- | --- | --- |
+| `src/cli_structure.rs:150` (`run_list_tui`) | `?` → `match_user_action` → `src/main.rs:43-49` `eprintln!` + `exit(1)` | **Already loud.** No change needed. |
+| `src/cli_structure.rs:128` (`Remove` arm) | `let _ = remove_cv(ctx, &filters);` | **Silently swallowed.** Must propagate. |
+| `src/cv_insert.rs:29-42` | `warn!("Could not save CV to database: {e:}")` | **Effectively silent** — `env_logger` (`src/main.rs:33`) defaults to `Error`, so `warn!` prints nothing without `RUST_LOG`. |
+
+`src/cv_insert.rs` is a deliberate design ("A failed DB save must not discard a
+successfully generated CV", `src/cv_insert.rs:28`). A missing password is a
+*configuration* error, not a transient DB error, and the decided shape requires it to be
+loud. Minimum change consistent with both: give the missing-password error a
+distinguishable type (or check `RUSTY_CV_DB_PASSWORD` in a pre-flight in `main` when the
+resolved engine is postgres and `--save-to-database` is set) so it reaches stderr while
+genuine connection failures keep the warn-and-continue behaviour. **Decision point for
+the maintainer** — flagged, not chosen here.
+
+### 7.3 Files explicitly NOT to change
+
+`src/database.rs` (config-free by ADR-0003/0006) · `src/config_parse.rs:83-86` (sqlite
+arm) · `src/helpers.rs:118-124` (sqlite arm) · `env.sample:1` value ·
+`tests/tui_job_applications_scenarios.rs:31`.
+
+---
+
+## 8. Regression-test plan
+
+### 8.1 The test that would have caught a credential literal landing in a tracked config file
+
+**`tests/no_tracked_credentials.rs`** — a normal (non-`#[ignore]`) integration test so
+`.github/workflows/rust-tests.yml` runs it on every push.
+
+- **Source of truth**: `git ls-files -z` from `env!("CARGO_MANIFEST_DIR")` — scans the
+  *tracked* set, so untracked local configs and `.env` are correctly out of scope.
+- **Detection**: regex over each file's text —
+  `(?i)\b(postgres|postgresql|mysql|mongodb|redis|amqp|https?)://[^\s"'/]*:[^\s"'@/]+@`
+  (scheme, then userinfo containing a `:`-separated non-empty password, then `@`).
+- **Assertion**: zero matches. Failure message prints `file:line` and the matched
+  scheme+user with the password redacted.
+- **Allowlist**: empty by construction — that is why `tests/integration-tests.rs:44`
+  must be cleaned first (§7.1 #7). An allowlist is where this class of test goes to die.
+- **Self-test (guards against a silently-broken regex)**: assert the matcher fires on a
+  known-bad string assembled at runtime from fragments, so the test file itself does not
+  trip the scan.
+- **Historical proof**: the same matcher run against `git show 53ceda1:rusty-cv-config-example.ini`
+  and `git show fef6db6:devenv.nix` must match — i.e. it *would* have blocked both
+  original commits. Verify manually once; do not commit as a test (it would pin history).
+- **Fast local feedback**: add a real scanner to `devenv.nix` `git-hooks.hooks` (gitleaks
+  or ripsecrets) at stage `pre-commit`. Pre-commit sees only staged files; the cargo test
+  sees the whole tracked tree. Both are needed. Also add `--allow-missing-credentials` to
+  `detect-aws-credentials` (`devenv.nix:101-105`) or drop the hook — today it exits 2
+  wherever no `~/.aws` exists (Branch C, secondary).
+
+### 8.2 The test that proves the loud failure on a missing password variable
+
+Three layers. Env-mutating tests use `#[serial_test::serial]` with save/restore — the
+pattern already in the repo at `src/helpers.rs:274-289` and
+`tests/integration-tests.rs:236-245`. (`cargo-nextest` isolates per process, but
+`cargo test` uses threads and `tests/integration-tests.rs:78` sets `DATABASE_URL`
+without restoring it — serial is mandatory.)
+
+**Layer 1 — unit, on the splice helper (`src/config_parse.rs`):**
+
+| Case | `RUSTY_CV_DB_PASSWORD` | Expected |
+| --- | --- | --- |
+| unset | `env_remove` | `Err`; message contains `RUSTY_CV_DB_PASSWORD` |
+| empty | `""` | `Err`; same message |
+| whitespace | `"   "` | `Err`; same message |
+| valid | `"s3cret"` | `Ok`; URL contains `rusty_cv:s3cret@`, and host `nixos-02…` + db `/rusty_cv` preserved byte-for-byte |
+| **no-fallback guard** | unset | returned value is `Err`, and no code path returns the base URL — assert the `Err` branch explicitly rather than `is_err()` alone |
+| base already has a password | any | `Err`, distinct message (guards the stale live INI, R-1) |
+
+**Layer 2 — `resolve_db_target` integration (`src/config_parse.rs:72`):** build an `Ini`
+with `[db] engine = "postgres"` and a passwordless `db_pg_host`; with the var unset,
+assert `Err`. With the var set, assert the returned tuple is
+`("postgres", "<url with password>")`. Mirror with `engine = "sqlite"` and the var unset
+→ `Ok`, proving **the sqlite path is unaffected**.
+
+**Layer 3 — subprocess, proving end-to-end loudness** (pattern:
+`tests/tui_job_applications_scenarios.rs:79-118`): run `CARGO_BIN_EXE_rusty_cv_creator`
+with a temp INI (`engine = "postgres"`, passwordless `db_pg_host`) and
+`.env_remove("RUSTY_CV_DB_PASSWORD")`. Assert **non-zero exit** and that combined
+stdout+stderr contains `RUSTY_CV_DB_PASSWORD`. This is the only layer that catches the
+error being swallowed at `src/cli_structure.rs:128` or downgraded to `warn!` at
+`src/cv_insert.rs:41` (contributing factor H) — a unit test alone will pass while the
+binary stays silent.
+
+**Layer 4 — sqlite non-regression (must stay green with `RUSTY_CV_DB_PASSWORD` unset):**
+`tests/integration-tests.rs:78`, `tests/tui_job_applications_scenarios.rs:62`, `:86`,
+`:111`, `tests/tui_job_applications_specifications.rs:140-146`,
+`src/database.rs:152-158`.
+
+**Layer 5 — password-encoding property test:** `proptest` over passwords drawn from an
+alphabet including `@ : / ? # % [ ] space`; assert the spliced URL parses back to the
+same host, database, user, and password. Sops-generated passwords routinely contain these
+(§8 R-6). The repo already uses proptest (`tests/integration-tests.proptest-regressions`).
+
+---
+
+## 9. Risk assessment for the decided fix
+
+Ordered by expected damage.
+
+**R-1 — The live INI still contains the password, and it is outside this commit's
+reach. HIGH.**
+`~/.config/rusty-cv-creator/rusty-cv-config.ini` currently holds
+`postgres://rusty_cv:<pw>@nixos-02…/rusty_cv`. After the fix, `splice_db_password`
+receives that string as its "base". Naive insertion yields
+`postgres://rusty_cv:<old>:<new>@nixos-02…` — malformed, and the failure mode is a
+confusing parse/auth error rather than the intended actionable message.
+*Mitigation (mandatory)*: the `base_url` already-has-a-password check in §7.2 item 4,
+with an error that says exactly which file to edit and what to delete. Plus a
+release-note line: strip the password from the live INI before upgrading. This is the
+one breakage the user will actually hit.
+
+**R-2 — Cannot prove a real connect: the database exists on no host. MEDIUM (schedule,
+not correctness).**
+`nixos-02`/`rusty_cv` is being recreated by a parallel lane. Any end-to-end
+`PgConnection::establish` will fail regardless of this fix, so a red test is not evidence
+of a defect here.
+*Mitigation*: define done as **(i)** the assembled URL asserted string-wise against an
+expected literal, and **(ii)** the loud-failure behaviour proven by §8.2 Layers 1-3 —
+neither needs a server. When `nixos-02` comes up, the one remaining check is that a
+successful connect distinguishes *auth failure* (wrong password → the splice works, the
+secret is stale) from *config error* (missing variable). Record as an open verification
+item; do not let it block the merge.
+
+**R-3 — "Fail loudly" is not achieved by returning `Err` alone. MEDIUM.**
+Two of the three call chains discard it: `src/cli_structure.rs:128` (`let _ =`) and
+`src/cv_insert.rs:41` (`warn!`, invisible at `env_logger`'s default `Error` level, set at
+`src/main.rs:33`). A fix that only touches `resolve_db_target` will pass unit tests and
+still be silent for a user doing `insert --save-to-database` — the single most common
+postgres operation.
+*Mitigation*: §8.2 Layer 3 subprocess test is the gate. Ship the loudness plumbing in the
+same commit as the splice, never after.
+
+**R-4 — Removing `devenv.nix:25` breaks `diesel-cli` in the dev shell. LOW-MEDIUM,
+certain to be noticed.**
+`diesel setup` / `diesel migration run` (`README.md:174-178`, `diesel-cli` at
+`devenv.nix:31`) read `DATABASE_URL` from the environment. Today the dev shell supplies
+it; after removal it is unset.
+*Mitigation*: `env.sample:1` already carries a correct sqlite `DATABASE_URL` — document
+copying it to the gitignored `.env` (`.gitignore` line `.env`; `dotenv.enable = true` at
+`devenv.nix:22` loads it at shell entry). For postgres migrations, pass it inline for
+that command only. Note the upside: removal also fixes E-1, where the exported
+`postgres://` URL was being fed to `SqliteConnection::establish`.
+
+**R-5 — `dotenvy` does not find `.env` outside the repo. MEDIUM on the real machine.**
+`src/main.rs:34` calls `dotenv().ok()`, which searches from the **current working
+directory** upward. The real user runs the binary from `~/Documents/CV_Applications`
+and similar, so the `.env` route is dev-only in practice.
+*Mitigation*: sops/home-manager must export `RUSTY_CV_DB_PASSWORD` into the **user
+session** environment (systemd user environment / `home.sessionVariables`), not only into
+an interactive shell rc. If it lands only in `.zshrc`, non-interactive invocations
+(cron, desktop launchers, `systemd --user` units) will fail loudly on every postgres run
+— correct behaviour, maximally annoying. Hand this constraint to the home-manager lane
+explicitly.
+
+**R-6 — Special characters in the sops-generated password corrupt the URL. MEDIUM.**
+`@ : / ? # %` and space are all legal in a generated password and all significant in a
+URL. Unencoded splicing silently produces a wrong host or a truncated password, and the
+error surfaces as an auth failure — the hardest kind to debug against a DB that does not
+exist yet (R-2).
+*Mitigation*: percent-encode (§7.2 item 2) plus the property test at §8.2 Layer 5.
+
+**R-7 — Test-suite blast radius. LOW.**
+`tests/integration-tests.rs:44` fixture edit is inert (`engine = "sqlite"` at `:43`). New
+env-var tests must be `#[serial_test::serial]` — `tests/integration-tests.rs:78` sets
+`DATABASE_URL` process-wide and never restores it, so an unserialized test will flake
+under `cargo test`'s threading (nextest's process-per-test would hide it locally and CI
+would differ).
+
+**R-8 — The secret is already burned. Not fixed by this change. HIGH, out of scope but
+must be recorded.**
+`REDACTED-SEE-SOPS` has been in git history since `53ceda1` (2024-07-28) and remains in every
+clone and every CI checkout after this fix. Removing it from the working tree changes
+nothing about history.
+*Required follow-up*: rotate the `rusty_cv` role password on `nixos-02` as part of the
+database recreation, so the new sops secret is never the burned one. Decide separately
+whether to rewrite history (`git filter-repo`) or accept it — rotation makes the
+exposure inert either way, and is the cheaper of the two.
+
+**R-9 — Rollback path. LOW (this is the good news).**
+The sqlite arm is untouched, so `engine = "sqlite"` in the INI remains a fully working
+escape hatch if the postgres path misbehaves. No migration, no data movement, no schema
+change is involved in this fix. **Caveat**: the rollback is INI-only — the `--engine`
+flag (`src/cli_structure.rs:32-34`) is dead code and cannot be used for it (see §11.4).
+
+**R-10 — Quoted INI values may defeat the fix entirely. MEDIUM-HIGH, cheap to check
+first.**
+Per E-3, `get_user_input_db_engine` and `get_user_input_db_url`
+(`src/global_conf.rs:137-145`) do not strip quotes, unlike every other config reader
+(`src/config_parse.rs:50`, `:58-59`). If the live INI quotes its values, then **today**
+the engine `match` at `src/config_parse.rs:75` never selects the `postgres` arm, and
+**after the fix** the password would be spliced into a URL that still carries literal
+`"` characters. The visible symptom in both cases is a connection error that looks like
+a credential problem — maximally misleading against a database that does not exist yet
+(R-2).
+*Mitigation*: apply `clean_string_from_quotes` in both accessors (§7.2 item 0) and add a
+test with a quoted-value INI (`engine = "postgres"`, quoted `db_pg_host`) asserting that
+`resolve_db_target` selects the postgres arm and returns an unquoted URL. **Check the
+live INI's quoting before writing any code** — it determines whether this is a
+pre-existing outage being uncovered or a non-issue.
+
+---
+
+## 10. Solution map — every root cause has a mapped solution
+
+| Root cause | Solution | Type | Priority |
+| --- | --- | --- | --- |
+| **A** — URL modelled as one opaque string, no secret seam | Passwordless base URL in the INI + `RUSTY_CV_DB_PASSWORD` spliced at connect time (§7.2); the `GITHUB_TOKEN` env-only rule extended to the DB password | Permanent fix | P1 |
+| **B** — three unaware copies, only the untracked one executed | Delete `devenv.nix:25` (one copy gone); reconcile the example INI onto `nixos-02`/`rusty_cv` (§7.1 #2); README stops instructing a fourth copy (§7.1 #3) | Permanent fix | P1 |
+| **C** — no generic secret scanner, never adversarially tested | Tracked-tree credential scan as a CI-run cargo test (§8.1) + a real scanner hook in `devenv.nix`; fix or drop `detect-aws-credentials` | Early detection | P1 |
+| **D** — unverified "no secrets" claim standing in for a control | Rewrite `brief.md:175-176` to the realized state, citing the scan test as the evidence (§7.1 #9); record the exposure and its rotation status | Prevention | P2 |
+| **E-1** — inverted precedence, postgres URL poisoning the sqlite arm | Removing `devenv.nix:25` resolves it in practice; document the one remaining rule (postgres = INI + env password; sqlite = env-first) in the `resolve_db_target` doc comment | Permanent fix | P1 (free with B) |
+| **E-2** — secret exported to every subprocess | Delete the env-set at `src/helpers.rs:86-92`; splice into a local `String` only, never `set_var` (§7.2) | Permanent fix | P1 |
+| **H** — errors swallowed at two of three call chains | Propagate at `src/cli_structure.rs:128`; distinguish config-error from DB-error at `src/cv_insert.rs:29-42`; gated by the §8.2 Layer 3 subprocess test | Permanent fix | P1 |
+| **E-3** — quotes never stripped on the DB accessors | Apply `clean_string_from_quotes` in `get_user_input_db_engine` and `get_user_input_db_url` (`src/global_conf.rs:137-145`), plus a quoted-INI test (§8.2 / R-10) | Permanent fix | P1 (prerequisite — the splice is worthless if the postgres arm is never selected) |
+| **J** — credential-shaped test fixture | Clean `tests/integration-tests.rs:44` to passwordless so the scanner needs no allowlist | Prevention | P1 (blocks §8.1) |
+| **R-8** — burned secret in git history | Rotate the `rusty_cv` password during the nixos-02 recreation | Mitigation | P0 (schedule with the parallel lane) |
+
+**Immediate mitigation vs permanent fix.** There is no active incident, so no mitigation
+is required to restore service. The one time-sensitive item is **R-8 (rotation)**, which
+should ride the nixos-02 recreation lane already in flight — after that, everything above
+is a permanent fix or a prevention measure.
+
+---
+
+## 11. Open verification items
+
+1. **Live connect unproven** (R-2) — re-verify once `nixos-02`/`rusty_cv` exists.
+   *Hypothesis until then: the spliced URL is correct; only string-level assertions back it.*
+2. **Rotation status of `REDACTED-SEE-SOPS`** (R-8) — unknown at the time of this analysis.
+3. **sops/home-manager delivery scope** (R-5) — whether `RUSTY_CV_DB_PASSWORD` reaches
+   non-interactive user-session processes is a property of the home-manager lane, not
+   verifiable from this repo.
+4. **`--engine` is dead code — CONFIRMED, not just suspected.** `src/cli_structure.rs:32-34`
+   defines `--engine` (default `sqlite`), but `UserInput.engine` is never read anywhere:
+   a grep for `engine` across `src/` and `tests/` yields only struct-literal
+   initialisations in test fixtures, plus the three `resolve_db_target`/`establish_connection`
+   destructurings, plus `get_user_input_db_engine` — which reads the **INI**
+   (`src/global_conf.rs:137-139` → `[db] engine`), not the flag. The CLI flag therefore
+   has no effect on any code path. Consequence for this work: engine selection and the
+   R-9 rollback are INI-only. Out of this defect's scope to fix, but it must not be
+   relied on.
+
+5. **Does the live INI quote its values?** (E-3 / R-10) — determines whether the postgres
+   path is currently broken independently of the credential issue. One `grep` by the
+   maintainer settles it; everything in E-3 is conditional on the answer.

--- a/docs/product/architecture/brief.md
+++ b/docs/product/architecture/brief.md
@@ -181,19 +181,29 @@ core; effects (subprocess, fs, db) live in the shell and behind ports.
     tracked-tree credential scan (`tests/db_credentials_regression.rs`), which
     runs in CI and fails on any URL carrying a password in its userinfo, in
     every tracked file except markdown prose and non-UTF-8 binaries. There is
-    no allowlist: a hit fixes the offending file, never the scanner.
+    no allowlist: a hit fixes the offending file, never the scanner. What the
+    scan does **not** catch, so the guarantee is only as wide as this: it
+    matches the URL-userinfo shape and reads one line at a time, so a bare
+    `db_password = "..."` key, or a credential wrapped across two lines, would
+    pass. Widening it is future work, not a claim made here.
   - **In this process's environment — deliberately.** That is the delivery
     mechanism, not a defect. The program does not write the password there: it
     reads the variable, holds the value in a local `String`, and hands it to
     the connection. It does write `DATABASE_URL` at startup from the
     configured `db_pg_host` (`helpers.rs`), so a config whose URL still carries
     inline userinfo puts a password in this process's environment too.
-  - **Not in any child process's environment.** Every subprocess is built by
-    `child_env::command_without_db_credentials`, which removes **both**
-    `RUSTY_CV_DB_PASSWORD` and `DATABASE_URL`, so the PDF viewer, `xdg-open`
-    and the browser it starts, `git`, `sudo` and `tailscale` cannot expose
-    either through `/proc/<pid>/environ`. Stripping `DATABASE_URL` matters
-    because the startup write happens before the first child is spawned.
+  - **No DATABASE credential in any child process's environment.** Every
+    subprocess is built by `child_env::command_without_db_credentials`, which
+    removes **both** `RUSTY_CV_DB_PASSWORD` and `DATABASE_URL`, so the PDF
+    viewer, `xdg-open` and the browser it starts, `git`, `sudo` and
+    `tailscale` cannot expose either through `/proc/<pid>/environ`. Stripping
+    `DATABASE_URL` matters because the startup write happens before the first
+    child is spawned. **`GITHUB_TOKEN` is deliberately NOT stripped** and is
+    still inherited by every child, including the browser: `git` needs it for
+    template authentication (`template_source.rs`), so closing that leak means
+    scrubbing by default and re-injecting it on the git calls only. That is
+    tracked as its own change, not done here. Read this bullet as "database
+    credentials", not "all credentials".
     Enforced by `tests/child_env_scrubbing.rs`, which carries a control test
     proving an unscrubbed child does inherit them.
 

--- a/docs/product/architecture/brief.md
+++ b/docs/product/architecture/brief.md
@@ -179,15 +179,24 @@ core; effects (subprocess, fs, db) live in the shell and behind ports.
   connecting. What is actually guaranteed, and what enforces each claim:
   - **Not in the repository, not in the INI config.** Enforced by the
     tracked-tree credential scan (`tests/db_credentials_regression.rs`), which
-    runs in CI and fails on any URL carrying a password in its userinfo, in
-    every tracked file except markdown prose and non-UTF-8 binaries. There is
-    no allowlist: a hit fixes the offending file, never the scanner. What the
-    scan does **not** catch, so the guarantee is only as wide as this: it
-    matches the URL-userinfo shape and reads one line at a time, so a bare
-    `db_password = "..."` key, or a credential wrapped across two lines, would
-    pass. Nor does it match a user or password containing whitespace - that
-    exclusion is what keeps ordinary prose from tripping it, and it is pinned
-    by a test. Widening any of this is future work, not a claim made here.
+    runs in CI and fails on any URL carrying a password - in its userinfo, or
+    as a password-bearing query parameter - in every tracked file except
+    markdown prose and non-UTF-8 binaries. There is no allowlist: a hit fixes
+    the offending file, never the scanner. The query-parameter half is shared
+    with the code that rejects such a URL at connect time
+    (`rusty_cv_creator::db_url`), deliberately: they were once written twice
+    and both copies had the same blind spot.
+
+    What the scan does **not** catch, so the guarantee is only as wide as
+    this. The list is not claimed to be exhaustive - four of these were found
+    by someone attacking it, not by writing it:
+    - it reads one line at a time, so a credential wrapped across two lines
+      passes;
+    - it matches URL shapes, so a bare `db_password = "..."` key passes;
+    - it ignores a user or password containing whitespace, which is what keeps
+      ordinary prose from tripping it, pinned by a test;
+    - it cannot see a credential in a non-UTF-8 file, or one assembled at
+      runtime from fragments.
   - **In this process's environment — deliberately.** That is the delivery
     mechanism, not a defect. The program does not write the password there: it
     reads the variable, holds the value in a local `String`, and hands it to

--- a/docs/product/architecture/brief.md
+++ b/docs/product/architecture/brief.md
@@ -173,16 +173,31 @@ core; effects (subprocess, fs, db) live in the shell and behind ports.
 - **Functional suitability** — variant resolution precedence
   (flag → inference → default) covers explicit and implicit selection.
 - **Security** — single-user local tool; Postgres reached only over Tailscale.
-  The Postgres password is injected from the `RUSTY_CV_DB_PASSWORD` environment
-  variable (sops via home-manager) and spliced into the configured passwordless
-  URL at connect time; it is never stored in the repo, in the INI config, or in
-  the process environment. Enforced by a tracked-tree credential scan in the
-  test suite (`tests/db_credentials_regression.rs`), which runs in CI and fails
-  on any `scheme://user:secret@host` in a machine-read file. The devenv
-  `detect-private-keys` / `detect-aws-credentials` hooks are **not** the control
-  here — neither can match a URL userinfo password. Historical exposure: a
-  plaintext password was tracked from 2024-07-28 to 2026-07-30 and is in git
-  history; rotation rides the nixos-02 database recreation.
+  The Postgres password is delivered **through the process environment**: sops
+  exports `RUSTY_CV_DB_PASSWORD` via home-manager, the program reads it, and
+  splices it into the configured passwordless URL immediately before
+  connecting. What is actually guaranteed, and what enforces each claim:
+  - **Not in the repository, not in the INI config.** Enforced by the
+    tracked-tree credential scan (`tests/db_credentials_regression.rs`), which
+    runs in CI and fails on any URL carrying a password in its userinfo, in
+    every tracked file except markdown prose and non-UTF-8 binaries. There is
+    no allowlist: a hit fixes the offending file, never the scanner.
+  - **In this process's environment — deliberately.** That is the delivery
+    mechanism, not a defect. The program does not write it there: it reads the
+    variable, holds the value in a local `String`, and hands it to the
+    connection.
+  - **Not in any child process's environment.** Every subprocess is built by
+    `child_env::command_without_db_password`, which removes the variable, so
+    the PDF viewer, `xdg-open` and the browser it starts, `git`, `sudo` and
+    `tailscale` cannot expose it through `/proc/<pid>/environ`. Enforced by
+    `tests/child_env_scrubbing.rs`.
+
+  The devenv `detect-private-keys` / `detect-aws-credentials` hooks are **not**
+  the control here — neither can match a URL userinfo password, and the brief
+  claiming otherwise is what let the leak sit unnoticed for two years.
+  Historical exposure: a plaintext password was tracked from 2024-07-28 to
+  2026-07-30 and is in git history; rotation rides the nixos-02 database
+  recreation.
 
 ### Decisions table
 

--- a/docs/product/architecture/brief.md
+++ b/docs/product/architecture/brief.md
@@ -183,14 +183,19 @@ core; effects (subprocess, fs, db) live in the shell and behind ports.
     every tracked file except markdown prose and non-UTF-8 binaries. There is
     no allowlist: a hit fixes the offending file, never the scanner.
   - **In this process's environment — deliberately.** That is the delivery
-    mechanism, not a defect. The program does not write it there: it reads the
-    variable, holds the value in a local `String`, and hands it to the
-    connection.
+    mechanism, not a defect. The program does not write the password there: it
+    reads the variable, holds the value in a local `String`, and hands it to
+    the connection. It does write `DATABASE_URL` at startup from the
+    configured `db_pg_host` (`helpers.rs`), so a config whose URL still carries
+    inline userinfo puts a password in this process's environment too.
   - **Not in any child process's environment.** Every subprocess is built by
-    `child_env::command_without_db_password`, which removes the variable, so
-    the PDF viewer, `xdg-open` and the browser it starts, `git`, `sudo` and
-    `tailscale` cannot expose it through `/proc/<pid>/environ`. Enforced by
-    `tests/child_env_scrubbing.rs`.
+    `child_env::command_without_db_credentials`, which removes **both**
+    `RUSTY_CV_DB_PASSWORD` and `DATABASE_URL`, so the PDF viewer, `xdg-open`
+    and the browser it starts, `git`, `sudo` and `tailscale` cannot expose
+    either through `/proc/<pid>/environ`. Stripping `DATABASE_URL` matters
+    because the startup write happens before the first child is spawned.
+    Enforced by `tests/child_env_scrubbing.rs`, which carries a control test
+    proving an unscrubbed child does inherit them.
 
   The devenv `detect-private-keys` / `detect-aws-credentials` hooks are **not**
   the control here — neither can match a URL userinfo password, and the brief

--- a/docs/product/architecture/brief.md
+++ b/docs/product/architecture/brief.md
@@ -172,8 +172,17 @@ core; effects (subprocess, fs, db) live in the shell and behind ports.
   (ADR-0004) instead of cryptic subprocess errors.
 - **Functional suitability** — variant resolution precedence
   (flag → inference → default) covers explicit and implicit selection.
-- **Security** — single-user local tool; Postgres reached only over Tailscale;
-  no secrets in repo (pre-commit hooks for keys/AWS creds in devenv).
+- **Security** — single-user local tool; Postgres reached only over Tailscale.
+  The Postgres password is injected from the `RUSTY_CV_DB_PASSWORD` environment
+  variable (sops via home-manager) and spliced into the configured passwordless
+  URL at connect time; it is never stored in the repo, in the INI config, or in
+  the process environment. Enforced by a tracked-tree credential scan in the
+  test suite (`tests/db_credentials_regression.rs`), which runs in CI and fails
+  on any `scheme://user:secret@host` in a machine-read file. The devenv
+  `detect-private-keys` / `detect-aws-credentials` hooks are **not** the control
+  here — neither can match a URL userinfo password. Historical exposure: a
+  plaintext password was tracked from 2024-07-28 to 2026-07-30 and is in git
+  history; rotation rides the nixos-02 database recreation.
 
 ### Decisions table
 

--- a/docs/product/architecture/brief.md
+++ b/docs/product/architecture/brief.md
@@ -185,7 +185,9 @@ core; effects (subprocess, fs, db) live in the shell and behind ports.
     scan does **not** catch, so the guarantee is only as wide as this: it
     matches the URL-userinfo shape and reads one line at a time, so a bare
     `db_password = "..."` key, or a credential wrapped across two lines, would
-    pass. Widening it is future work, not a claim made here.
+    pass. Nor does it match a user or password containing whitespace - that
+    exclusion is what keeps ordinary prose from tripping it, and it is pinned
+    by a test. Widening any of this is future work, not a claim made here.
   - **In this process's environment — deliberately.** That is the delivery
     mechanism, not a defect. The program does not write the password there: it
     reads the variable, holds the value in a local `String`, and hands it to

--- a/env.sample
+++ b/env.sample
@@ -1,1 +1,7 @@
 DATABASE_URL=sqlite://$HOME/.config/rusty-cv-creator/applications.db
+
+# Postgres engine only. The config file holds a passwordless db_pg_host; the
+# password is read from this variable at connect time and is never stored in a
+# tracked file. On the real machine it is exported from sops by home-manager;
+# in development, copy this file to .env (gitignored) and set it there.
+# RUSTY_CV_DB_PASSWORD=

--- a/rusty-cv-config-example.ini
+++ b/rusty-cv-config-example.ini
@@ -61,7 +61,13 @@ db_path = "~/.config/rusty-cv-creator"
 # db_file is only used for the sqlite3 database
 db_file = "applications.db"
 
-db_pg_host = "postgres://rusty_cv:rusty-cv-01@nixos-01.caracara-palermo.ts.net/db_rusty_cv"
+# Passwordless connection URL for the postgres engine: scheme, database user,
+# host and database only. The password is read ONLY from the
+# RUSTY_CV_DB_PASSWORD environment variable — supplied by sops through
+# home-manager on the real machine, or by the gitignored .env file in
+# development — and must never be written into this INI file. A URL that
+# already carries a password is rejected.
+db_pg_host = "postgres://rusty_cv@nixos-02.caracara-palermo.ts.net/rusty_cv"
 
 [destination]
 # Where the dated working copy of the repo is created before building.

--- a/src/child_env.rs
+++ b/src/child_env.rs
@@ -1,0 +1,22 @@
+//! The single place where this program builds a child process.
+//!
+//! Lives in the library crate rather than next to `CommandRunner` (which is
+//! binary-private) because the TUI's `xdg-open` / `open` spawn is a library
+//! call site: the choke point has to be reachable from both crates, and there
+//! must be exactly one of it.
+
+use std::process::Command;
+
+/// The environment variable carrying the PostgreSQL password. Canonical here so
+/// the name that is scrubbed and the name that is read are one literal.
+pub const DB_PASSWORD_ENV: &str = "RUSTY_CV_DB_PASSWORD";
+
+/// Build a `Command` whose child cannot see the database password: the password
+/// is delivered to this process only, and any child - a PDF viewer, `xdg-open`
+/// and the browser it starts, `git`, `sudo`, `tailscale` - would otherwise carry
+/// it in its own environment, readable from /proc, for its whole lifetime.
+pub fn command_without_db_password(program: &str) -> Command {
+    let mut command = Command::new(program);
+    command.env_remove(DB_PASSWORD_ENV);
+    command
+}

--- a/src/child_env.rs
+++ b/src/child_env.rs
@@ -11,12 +11,20 @@ use std::process::Command;
 /// the name that is scrubbed and the name that is read are one literal.
 pub const DB_PASSWORD_ENV: &str = "RUSTY_CV_DB_PASSWORD";
 
-/// Build a `Command` whose child cannot see the database password: the password
-/// is delivered to this process only, and any child - a PDF viewer, `xdg-open`
-/// and the browser it starts, `git`, `sudo`, `tailscale` - would otherwise carry
-/// it in its own environment, readable from /proc, for its whole lifetime.
-pub fn command_without_db_password(program: &str) -> Command {
+/// The connection URL this program writes into its own environment at startup.
+/// It is scrubbed from children too: a URL configured with inline userinfo
+/// carries a password just as surely as `DB_PASSWORD_ENV` does, and the
+/// startup write happens before the first child is spawned.
+pub const DB_URL_ENV: &str = "DATABASE_URL";
+
+/// Build a `Command` whose child cannot see the database credentials: they are
+/// delivered to this process only, and any child - a PDF viewer, `xdg-open`
+/// and the browser it starts, `git`, `sudo`, `tailscale` - would otherwise
+/// carry them in its own environment, readable from /proc, for its whole
+/// lifetime. A desktop browser's lifetime is the whole session.
+pub fn command_without_db_credentials(program: &str) -> Command {
     let mut command = Command::new(program);
     command.env_remove(DB_PASSWORD_ENV);
+    command.env_remove(DB_URL_ENV);
     command
 }

--- a/src/cli_structure.rs
+++ b/src/cli_structure.rs
@@ -3,6 +3,7 @@ use crate::global_conf::AppContext;
 use crate::{cv_insert::insert_cv, user_action::remove_cv};
 use chrono::NaiveDate;
 use clap::{Args, Parser, Subcommand};
+use log::error;
 
 #[derive(Parser, Debug, Clone)]
 #[command(version, about, long_about = None)]
@@ -125,7 +126,9 @@ pub fn match_user_action(
         UserAction::Insert(_) => insert_cv(ctx),
 
         UserAction::Remove(filters) => {
-            let _ = remove_cv(ctx, &filters);
+            if let Err(e) = remove_cv(ctx, &filters) {
+                error!("Could not remove the CV: {e:}");
+            }
             let out = format!("filter args for LIST: {filters:?}");
             println!("{out:?}");
             Ok(out)

--- a/src/cli_structure.rs
+++ b/src/cli_structure.rs
@@ -1,4 +1,4 @@
-use crate::config_parse::resolve_db_target;
+use crate::config_parse::connect_db;
 use crate::global_conf::AppContext;
 use crate::{cv_insert::insert_cv, user_action::remove_cv};
 use chrono::NaiveDate;
@@ -150,8 +150,7 @@ pub fn match_user_action(
 /// application through the v5 `DbConnection` seam and hand it to the pure-UI TUI.
 fn run_list_tui(ctx: &AppContext) -> Result<(), Box<dyn std::error::Error>> {
     rusty_cv_creator::tui::probe::run_startup_probe()?;
-    let (engine, url) = resolve_db_target(ctx)?;
-    let mut conn = rusty_cv_creator::database::establish_connection(&engine, &url)?;
+    let mut conn = connect_db(ctx)?;
     let cvs = rusty_cv_creator::database::load_all_applications(&mut conn)?;
     rusty_cv_creator::tui::run(cvs)
 }

--- a/src/command_runner.rs
+++ b/src/command_runner.rs
@@ -1,5 +1,6 @@
+use rusty_cv_creator::child_env::command_without_db_password;
 use std::io;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 /// Captured outcome of a subprocess run (UC-1, feature `template-source`):
 /// success plus both streams, so a caller can classify a git failure from its
@@ -46,12 +47,13 @@ pub trait CommandRunner {
     }
 }
 
-/// The real runner, backed by `std::process::Command`.
+/// The real runner. Every child is built by `command_without_db_password`, never
+/// by `Command::new` directly, so no subprocess inherits the database password.
 pub struct SystemRunner;
 
 impl CommandRunner for SystemRunner {
     fn status(&self, program: &str, args: &[&str], cwd: Option<&str>) -> io::Result<bool> {
-        let mut cmd = Command::new(program);
+        let mut cmd = command_without_db_password(program);
         cmd.args(args);
         if let Some(dir) = cwd {
             cmd.current_dir(dir);
@@ -60,13 +62,13 @@ impl CommandRunner for SystemRunner {
     }
 
     fn output(&self, program: &str, args: &[&str]) -> io::Result<(bool, String)> {
-        let out = Command::new(program).args(args).output()?;
+        let out = command_without_db_password(program).args(args).output()?;
         let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
         Ok((out.status.success(), stdout))
     }
 
     fn spawn(&self, program: &str, args: &[&str]) -> io::Result<()> {
-        Command::new(program)
+        command_without_db_password(program)
             .args(args)
             .stdout(Stdio::null())
             .spawn()?;
@@ -79,7 +81,7 @@ impl CommandRunner for SystemRunner {
         args: &[&str],
         cwd: Option<&str>,
     ) -> io::Result<CommandOutcome> {
-        let mut cmd = Command::new(program);
+        let mut cmd = command_without_db_password(program);
         cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
         if let Some(dir) = cwd {
             cmd.current_dir(dir);

--- a/src/command_runner.rs
+++ b/src/command_runner.rs
@@ -1,4 +1,4 @@
-use rusty_cv_creator::child_env::command_without_db_password;
+use rusty_cv_creator::child_env::command_without_db_credentials;
 use std::io;
 use std::process::Stdio;
 
@@ -47,13 +47,13 @@ pub trait CommandRunner {
     }
 }
 
-/// The real runner. Every child is built by `command_without_db_password`, never
+/// The real runner. Every child is built by `command_without_db_credentials`, never
 /// by `Command::new` directly, so no subprocess inherits the database password.
 pub struct SystemRunner;
 
 impl CommandRunner for SystemRunner {
     fn status(&self, program: &str, args: &[&str], cwd: Option<&str>) -> io::Result<bool> {
-        let mut cmd = command_without_db_password(program);
+        let mut cmd = command_without_db_credentials(program);
         cmd.args(args);
         if let Some(dir) = cwd {
             cmd.current_dir(dir);
@@ -62,13 +62,15 @@ impl CommandRunner for SystemRunner {
     }
 
     fn output(&self, program: &str, args: &[&str]) -> io::Result<(bool, String)> {
-        let out = command_without_db_password(program).args(args).output()?;
+        let out = command_without_db_credentials(program)
+            .args(args)
+            .output()?;
         let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
         Ok((out.status.success(), stdout))
     }
 
     fn spawn(&self, program: &str, args: &[&str]) -> io::Result<()> {
-        command_without_db_password(program)
+        command_without_db_credentials(program)
             .args(args)
             .stdout(Stdio::null())
             .spawn()?;
@@ -81,7 +83,7 @@ impl CommandRunner for SystemRunner {
         args: &[&str],
         cwd: Option<&str>,
     ) -> io::Result<CommandOutcome> {
-        let mut cmd = command_without_db_password(program);
+        let mut cmd = command_without_db_credentials(program);
         cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
         if let Some(dir) = cwd {
             cmd.current_dir(dir);

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -163,8 +163,10 @@ fn inject_db_password(
 ///
 /// - `postgres` -> the passwordless `db_pg_host` configured in the INI file,
 ///   with the password from the `RUSTY_CV_DB_PASSWORD` environment variable
-///   spliced in. The password lives in a local `String` handed straight to the
-///   connection: it is never written into the process environment.
+///   spliced in. The variable is already in this process's environment - that
+///   is how it arrives - and this function does not write it back there: the
+///   value lives in a local `String` handed straight to the connection.
+///   Children never see it; see `child_env::command_without_db_password`.
 /// - `sqlite`   -> the `DATABASE_URL` env var when set, otherwise a
 ///   `sqlite://<configured-path>` URL built from the INI config.
 pub fn resolve_db_target(ctx: &AppContext) -> Result<(String, String), Box<dyn std::error::Error>> {

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -111,10 +111,15 @@ fn percent_encode_password(password: &str) -> String {
 }
 
 /// The only schemes libpq parses as a URI. Anything else is treated as a
-/// keyword/value connection string, and its parse errors quote the WHOLE
-/// string back - password included - into a log line. Validating the scheme
-/// here is what keeps a one-character typo in `db_pg_host` from printing the
-/// spliced password to the terminal and the journal.
+/// keyword/value connection string, whose parse errors quote the WHOLE string
+/// back - password included.
+///
+/// This check is a guard rail, NOT the control that keeps the password out of
+/// the logs: libpq echoes the connection string from several other error
+/// branches too, and those fire on a perfectly valid `postgres://` scheme.
+/// The control is `connect_db`, which redacts the secret from whatever the
+/// driver produces. Rejecting a wrong scheme here just turns a confusing
+/// driver error into an actionable one.
 const POSTGRES_URI_SCHEMES: [&str; 2] = ["postgres", "postgresql"];
 
 /// Splice `password` into the userinfo of a passwordless `base_url`.
@@ -145,9 +150,7 @@ fn inject_db_password(
             "The configured database URL has scheme '{scheme}', which PostgreSQL \
              does not parse as a URL.\n  \
              Use 'postgres://' or 'postgresql://' in db_pg_host in the INI config \
-             file.\n  \
-             Refusing to connect: any other scheme makes the driver echo the whole \
-             connection string, password included, into its error message."
+             file."
         )
         .into());
     }
@@ -211,6 +214,46 @@ pub fn resolve_db_target(ctx: &AppContext) -> Result<(String, String), Box<dyn s
         }
         _ => Ok((engine, String::new())),
     }
+}
+
+/// Replace every occurrence of `secret` in `message` with a marker.
+///
+/// Both the raw secret and its percent-encoded form are removed, because the
+/// value that ends up inside a connection URL is the encoded one while the
+/// value a human recognises is the raw one. An empty secret is a no-op.
+fn redact_secret(message: &str, secret: &str) -> String {
+    const MARKER: &str = "<password redacted>";
+
+    if secret.is_empty() {
+        return message.to_string();
+    }
+
+    message
+        .replace(secret, MARKER)
+        .replace(&percent_encode_password(secret), MARKER)
+}
+
+/// Open the database connection for this run, with the password scrubbed from
+/// any error before it can be logged.
+///
+/// Validating the URL is not enough on its own. libpq quotes the WHOLE
+/// connection string back in several of its parse errors - a malformed IPv6
+/// host is one - and those fire on a perfectly valid `postgres://` scheme, so
+/// the spliced password would reach stderr and the journal. Enumerating the
+/// driver's error branches is a losing game across versions; removing the
+/// secret from whatever it produces is not. Every caller must connect through
+/// here rather than calling `establish_connection` directly.
+pub fn connect_db(
+    ctx: &AppContext,
+) -> Result<rusty_cv_creator::database::DbConnection, Box<dyn std::error::Error>> {
+    let (engine, url) = resolve_db_target(ctx)?;
+
+    rusty_cv_creator::database::establish_connection(&engine, &url).map_err(
+        |e| -> Box<dyn std::error::Error> {
+            let secret = std::env::var(DB_PASSWORD_ENV).unwrap_or_default();
+            redact_secret(&e.to_string(), &secret).into()
+        },
+    )
 }
 
 #[cfg(test)]
@@ -516,5 +559,62 @@ mod tests {
             ("sqlite".to_string(), "sqlite:///tmp/test.db".to_string())
         );
         assert_eq!(without, with);
+    }
+
+    #[test]
+    fn test_redact_secret_removes_both_the_raw_and_encoded_forms() {
+        let secret = "p@ss w0rd";
+        let message = format!(
+            "failed on {} and on {}",
+            secret,
+            percent_encode_password(secret)
+        );
+
+        let redacted = redact_secret(&message, secret);
+
+        assert!(!redacted.contains(secret), "raw form survived: {redacted}");
+        assert!(
+            !redacted.contains(&percent_encode_password(secret)),
+            "encoded form survived: {redacted}"
+        );
+        assert_eq!(redacted.matches("<password redacted>").count(), 2);
+    }
+
+    #[test]
+    fn test_redact_secret_is_a_no_op_for_an_empty_secret() {
+        assert_eq!(redact_secret("nothing to hide", ""), "nothing to hide");
+    }
+
+    /// The reason `connect_db` exists. libpq quotes the whole connection
+    /// string back in several parse errors that fire on a valid `postgres://`
+    /// scheme - a malformed IPv6 host is the cheapest to trigger - so without
+    /// redaction the live password reaches stderr and the journal.
+    #[test]
+    #[serial_test::serial]
+    fn test_connect_db_never_echoes_the_password_when_the_driver_rejects_the_url() {
+        let _restore = EnvVarGuard::capture(DB_PASSWORD_ENV);
+        let secret = "ZZTOPSECRETpw987";
+        std::env::set_var(DB_PASSWORD_ENV, secret);
+
+        for host in ["[2001:db8::1", "[notipv6", "[]"] {
+            let ctx = context_from(&format!(
+                "[db]\nengine = \"postgres\"\n\
+                 db_pg_host = \"postgresql://rusty_cv@{host}/rusty_cv\""
+            ));
+
+            let err = connect_db(&ctx)
+                .err()
+                .expect("the driver must reject a malformed host")
+                .to_string();
+
+            assert!(
+                !err.contains(secret),
+                "the password leaked for host {host}: {err}"
+            );
+            assert!(
+                !err.contains(&percent_encode_password(secret)),
+                "the encoded password leaked for host {host}: {err}"
+            );
+        }
     }
 }

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -110,12 +110,19 @@ fn percent_encode_password(password: &str) -> String {
     encoded
 }
 
+/// The only schemes libpq parses as a URI. Anything else is treated as a
+/// keyword/value connection string, and its parse errors quote the WHOLE
+/// string back - password included - into a log line. Validating the scheme
+/// here is what keeps a one-character typo in `db_pg_host` from printing the
+/// spliced password to the terminal and the journal.
+const POSTGRES_URI_SCHEMES: [&str; 2] = ["postgres", "postgresql"];
+
 /// Splice `password` into the userinfo of a passwordless `base_url`.
 ///
 /// The base URL names the database user and carries no password:
 /// `postgres://<user>@<host>/<database>`. Errors when the base URL already
-/// carries a password (it would otherwise become `user:old:new@host`) and when
-/// it names no user at all.
+/// carries a password (it would otherwise become `user:old:new@host`), when it
+/// names no user at all, and when its scheme is not one libpq will URI-parse.
 fn inject_db_password(
     base_url: &str,
     password: &str,
@@ -130,6 +137,20 @@ fn inject_db_password(
     };
 
     let scheme_end = base_url.find("://").ok_or_else(missing_user)? + "://".len();
+
+    let scheme = &base_url[..scheme_end - "://".len()];
+    if !POSTGRES_URI_SCHEMES.contains(&scheme) {
+        return Err(format!(
+            "The configured database URL has scheme '{scheme}', which PostgreSQL \
+             does not parse as a URL.\n  \
+             Use 'postgres://' or 'postgresql://' in db_pg_host in the INI config \
+             file.\n  \
+             Refusing to connect: any other scheme makes the driver echo the whole \
+             connection string, password included, into its error message."
+        )
+        .into());
+    }
+
     let authority = &base_url[scheme_end..];
 
     let at = authority.find('@').ok_or_else(missing_user)?;
@@ -362,6 +383,40 @@ mod tests {
         ] {
             let err = inject_db_password(base, "s3cret").unwrap_err().to_string();
             assert!(err.contains("names no user"), "for {base}, got: {err}");
+        }
+    }
+
+    #[test]
+    fn test_inject_db_password_rejects_a_scheme_libpq_will_not_uri_parse() {
+        // A scheme libpq does not URI-parse is read as a keyword/value
+        // connection string, and its parse error quotes the whole string -
+        // spliced password included - into a log line. `postgres:://` is one
+        // extra colon away from the real thing.
+        for base in [
+            "postgres:://rusty_cv@host/db",
+            "postgress://rusty_cv@host/db",
+            "mysql://rusty_cv@host/db",
+            "https://rusty_cv@host/db",
+        ] {
+            let err = inject_db_password(base, "s3cret").unwrap_err().to_string();
+            assert!(
+                err.contains("does not parse as a URL"),
+                "for {base}, got: {err}"
+            );
+            assert!(
+                !err.contains("s3cret"),
+                "the rejection must not echo the password, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_inject_db_password_accepts_both_postgres_uri_schemes() {
+        for base in [
+            "postgres://rusty_cv@host/db",
+            "postgresql://rusty_cv@host/db",
+        ] {
+            assert!(inject_db_password(base, "s3cret").is_ok(), "for {base}");
         }
     }
 

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -127,13 +127,14 @@ fn inject_db_password(
     base_url: &str,
     password: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
+    // Deliberately does NOT echo `base_url`: an unmigrated config still holds
+    // an inline password, and printing it here would put it in the terminal
+    // and the journal - the very leak this module exists to close.
     let missing_user = || -> Box<dyn std::error::Error> {
-        format!(
-            "The configured database URL names no user: expected \
-             '<scheme>://<user>@<host>/<database>', got '{base_url}'.\n  \
-             Add the database user to db_pg_host in the INI config file."
-        )
-        .into()
+        "The configured database URL names no user: expected \
+         '<scheme>://<user>@<host>/<database>'.\n  \
+         Add the database user to db_pg_host in the INI config file."
+            .into()
     };
 
     let scheme_end = base_url.find("://").ok_or_else(missing_user)? + "://".len();

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -122,31 +122,16 @@ fn percent_encode_password(password: &str) -> String {
 /// driver error into an actionable one.
 const POSTGRES_URI_SCHEMES: [&str; 2] = ["postgres", "postgresql"];
 
-/// Does this URL carry a password as a query parameter?
-///
-/// PostgreSQL accepts `?password=` as well as userinfo, and prefers it over
-/// the value spliced into the userinfo - so without this check a config-file
-/// password would silently override the sops-supplied one, be invisible to the
-/// credential scan, and survive the redaction (which only knows the
-/// environment's value).
-fn has_password_query_parameter(url: &str) -> bool {
-    let Some((_, query)) = url.split_once('?') else {
-        return false;
-    };
-
-    query.split('&').any(|parameter| {
-        parameter
-            .split_once('=')
-            .is_some_and(|(key, value)| key.eq_ignore_ascii_case("password") && !value.is_empty())
-    })
-}
-
 /// Splice `password` into the userinfo of a passwordless `base_url`.
 ///
 /// The base URL names the database user and carries no password:
-/// `postgres://<user>@<host>/<database>`. Errors when the base URL already
-/// carries a password (it would otherwise become `user:old:new@host`), when it
-/// names no user at all, and when its scheme is not one libpq will URI-parse.
+/// `postgres://<user>@<host>/<database>`. Errors when it names no user at all,
+/// when its scheme is not one libpq will URI-parse, and when it already
+/// carries a password - either in the userinfo (which would otherwise become
+/// `user:old:new@host`) or as a password-bearing query parameter, which
+/// PostgreSQL would silently prefer over the spliced one. The query check
+/// lives in [`rusty_cv_creator::db_url`] and is shared with the tracked-tree
+/// credential scan, so the two cannot drift apart again.
 fn inject_db_password(
     base_url: &str,
     password: &str,
@@ -184,7 +169,7 @@ fn inject_db_password(
     }
 
     let userinfo = &authority[..at];
-    if userinfo.contains(':') || has_password_query_parameter(base_url) {
+    if userinfo.contains(':') || rusty_cv_creator::db_url::has_password_query_parameter(base_url) {
         return Err(format!(
             "The configured database URL already carries a password.\n  \
              Remove the password from db_pg_host in the INI config file: it now comes \

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -166,7 +166,7 @@ fn inject_db_password(
 ///   spliced in. The variable is already in this process's environment - that
 ///   is how it arrives - and this function does not write it back there: the
 ///   value lives in a local `String` handed straight to the connection.
-///   Children never see it; see `child_env::command_without_db_password`.
+///   Children never see it; see `child_env::command_without_db_credentials`.
 /// - `sqlite`   -> the `DATABASE_URL` env var when set, otherwise a
 ///   `sqlite://<configured-path>` URL built from the INI config.
 pub fn resolve_db_target(ctx: &AppContext) -> Result<(String, String), Box<dyn std::error::Error>> {

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -66,7 +66,10 @@ pub fn get_db_configurations(ctx: &AppContext) -> Result<String, Box<dyn std::er
 /// Environment variable carrying the PostgreSQL password. It is supplied by
 /// sops through home-manager on the real machine, and by the gitignored `.env`
 /// in development. It is never stored in the INI file nor in this repository.
-pub const DB_PASSWORD_ENV: &str = "RUSTY_CV_DB_PASSWORD";
+///
+/// Re-exported from `child_env` so the name this module reads and the name
+/// stripped from every child environment can never drift apart.
+pub use rusty_cv_creator::child_env::DB_PASSWORD_ENV;
 
 /// Read the PostgreSQL password from the environment.
 ///

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -301,6 +301,15 @@ mod tests {
         String::from_utf8(decoded).unwrap()
     }
 
+    /// Assemble a credential-bearing URL at runtime. Expected values are never
+    /// written as literals here: the tracked-tree credential scanner
+    /// (`tests/db_credentials_regression.rs`) has no allowlist, and this file
+    /// is one of the files it scans.
+    fn credentialed_url(user: &str, password: &str, host_and_database: &str) -> String {
+        let userinfo = format!("{user}{}{password}", ':');
+        format!("postgres://{userinfo}@{host_and_database}")
+    }
+
     #[test]
     fn test_inject_db_password_splices_into_the_userinfo() {
         let url = inject_db_password(
@@ -310,15 +319,18 @@ mod tests {
         .unwrap();
         assert_eq!(
             url,
-            "postgres://rusty_cv:s3cret@nixos-02.caracara-palermo.ts.net/rusty_cv"
+            credentialed_url(
+                "rusty_cv",
+                "s3cret",
+                "nixos-02.caracara-palermo.ts.net/rusty_cv"
+            )
         );
     }
 
     #[test]
     fn test_inject_db_password_rejects_a_base_url_that_already_has_one() {
-        let err = inject_db_password("postgres://rusty_cv:old@host/db", "new")
-            .unwrap_err()
-            .to_string();
+        let stale = credentialed_url("rusty_cv", "old", "host/db");
+        let err = inject_db_password(&stale, "new").unwrap_err().to_string();
         assert!(err.contains("already carries a password"), "got: {err}");
         assert!(err.contains("db_pg_host"), "got: {err}");
         assert!(err.contains(DB_PASSWORD_ENV), "got: {err}");
@@ -352,7 +364,10 @@ mod tests {
 
         assert_eq!(user, "rusty_cv");
         assert_eq!(percent_decode(encoded), password);
-        assert_eq!(url, "postgres://rusty_cv:p%40ss%3Aw%2Frd%23%3F%25@host/db");
+        assert_eq!(
+            url,
+            credentialed_url("rusty_cv", "p%40ss%3Aw%2Frd%23%3F%25", "host/db")
+        );
     }
 
     #[test]
@@ -399,7 +414,11 @@ mod tests {
         assert_eq!(engine, "postgres");
         assert_eq!(
             url,
-            "postgres://rusty_cv:s3cret@nixos-02.caracara-palermo.ts.net/rusty_cv"
+            credentialed_url(
+                "rusty_cv",
+                "s3cret",
+                "nixos-02.caracara-palermo.ts.net/rusty_cv"
+            )
         );
     }
 

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -268,21 +268,32 @@ mod tests {
         AppContext::new(load_config(config.to_string()), Local::now(), ui)
     }
 
-    /// Restore the password variable to whatever it was, so a serial test does
-    /// not leak its value into the next one.
-    struct PasswordVar(Option<String>);
+    /// Restore an environment variable to whatever it was, so a serial test
+    /// does not leak its value into the next one.
+    ///
+    /// The restore lives in `Drop` rather than in a trailing statement because
+    /// `cargo test` runs these threaded in one process: a panicking assertion
+    /// would skip a trailing restore and hand the leaked value to every
+    /// sibling test in the binary.
+    struct EnvVarGuard {
+        name: &'static str,
+        original: Option<String>,
+    }
 
-    impl PasswordVar {
-        fn capture() -> Self {
-            PasswordVar(std::env::var(DB_PASSWORD_ENV).ok())
+    impl EnvVarGuard {
+        fn capture(name: &'static str) -> Self {
+            EnvVarGuard {
+                name,
+                original: std::env::var(name).ok(),
+            }
         }
     }
 
-    impl Drop for PasswordVar {
+    impl Drop for EnvVarGuard {
         fn drop(&mut self) {
-            match self.0.take() {
-                Some(value) => std::env::set_var(DB_PASSWORD_ENV, value),
-                None => std::env::remove_var(DB_PASSWORD_ENV),
+            match self.original.take() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
             }
         }
     }
@@ -378,7 +389,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_resolve_db_target_postgres_errors_when_the_password_is_unset() {
-        let _restore = PasswordVar::capture();
+        let _restore = EnvVarGuard::capture(DB_PASSWORD_ENV);
         std::env::remove_var(DB_PASSWORD_ENV);
 
         let ctx = context_from(
@@ -393,7 +404,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_resolve_db_target_postgres_errors_when_the_password_is_empty() {
-        let _restore = PasswordVar::capture();
+        let _restore = EnvVarGuard::capture(DB_PASSWORD_ENV);
         std::env::set_var(DB_PASSWORD_ENV, "   ");
 
         let ctx = context_from(
@@ -407,7 +418,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_resolve_db_target_resolves_the_documented_quoted_config() {
-        let _restore = PasswordVar::capture();
+        let _restore = EnvVarGuard::capture(DB_PASSWORD_ENV);
         std::env::set_var(DB_PASSWORD_ENV, "s3cret");
 
         let ctx = context_from(
@@ -430,8 +441,8 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn test_resolve_db_target_sqlite_is_unaffected_by_the_password_variable() {
-        let _restore = PasswordVar::capture();
-        let original_url = std::env::var("DATABASE_URL").ok();
+        let _restore_password = EnvVarGuard::capture(DB_PASSWORD_ENV);
+        let _restore_url = EnvVarGuard::capture("DATABASE_URL");
         std::env::remove_var("DATABASE_URL");
 
         let ctx = context_from(
@@ -443,10 +454,6 @@ mod tests {
         let without = resolve_db_target(&ctx).unwrap();
         std::env::set_var(DB_PASSWORD_ENV, "s3cret");
         let with = resolve_db_target(&ctx).unwrap();
-
-        if let Some(url) = original_url {
-            std::env::set_var("DATABASE_URL", url);
-        }
 
         assert_eq!(
             without,

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -63,10 +63,105 @@ pub fn get_db_configurations(ctx: &AppContext) -> Result<String, Box<dyn std::er
     Ok(db_path)
 }
 
+/// Environment variable carrying the PostgreSQL password. It is supplied by
+/// sops through home-manager on the real machine, and by the gitignored `.env`
+/// in development. It is never stored in the INI file nor in this repository.
+pub const DB_PASSWORD_ENV: &str = "RUSTY_CV_DB_PASSWORD";
+
+/// Read the PostgreSQL password from the environment.
+///
+/// A missing, empty or blank value is a hard error: connecting without a
+/// password is never a fallback.
+fn read_db_password() -> Result<String, Box<dyn std::error::Error>> {
+    let password = std::env::var(DB_PASSWORD_ENV).unwrap_or_default();
+
+    if password.trim().is_empty() {
+        return Err(format!(
+            "The PostgreSQL password is missing: set {DB_PASSWORD_ENV} to a non-empty value.\n  \
+             It is supplied by sops through home-manager on the real machine, or by the \
+             gitignored .env file in development.\n  \
+             The password must never be written into the INI config file."
+        )
+        .into());
+    }
+
+    Ok(password)
+}
+
+/// Percent-encode `password` so URL-significant characters survive the splice.
+///
+/// Every byte except the RFC 3986 unreserved set (ASCII alphanumerics and
+/// `-` `.` `_` `~`) is escaped, which covers `@ : / # ? %` and whitespace.
+/// Hand-rolled on purpose: this must not pull in a new runtime dependency.
+fn percent_encode_password(password: &str) -> String {
+    let mut encoded = String::with_capacity(password.len());
+
+    for byte in password.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(byte as char);
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+
+    encoded
+}
+
+/// Splice `password` into the userinfo of a passwordless `base_url`.
+///
+/// The base URL names the database user and carries no password:
+/// `postgres://<user>@<host>/<database>`. Errors when the base URL already
+/// carries a password (it would otherwise become `user:old:new@host`) and when
+/// it names no user at all.
+fn inject_db_password(
+    base_url: &str,
+    password: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let missing_user = || -> Box<dyn std::error::Error> {
+        format!(
+            "The configured database URL names no user: expected \
+             '<scheme>://<user>@<host>/<database>', got '{base_url}'.\n  \
+             Add the database user to db_pg_host in the INI config file."
+        )
+        .into()
+    };
+
+    let scheme_end = base_url.find("://").ok_or_else(missing_user)? + "://".len();
+    let authority = &base_url[scheme_end..];
+
+    let at = authority.find('@').ok_or_else(missing_user)?;
+    let host_starts_before_userinfo_ends =
+        authority.find('/').is_some_and(|slash| slash < at) || at == 0;
+    if host_starts_before_userinfo_ends {
+        return Err(missing_user());
+    }
+
+    let userinfo = &authority[..at];
+    if userinfo.contains(':') {
+        return Err(format!(
+            "The configured database URL already carries a password.\n  \
+             Remove the password from db_pg_host in the INI config file: it now comes \
+             from the {DB_PASSWORD_ENV} environment variable.\n  \
+             Expected '<scheme>://<user>@<host>/<database>'."
+        )
+        .into());
+    }
+
+    Ok(format!(
+        "{}{}:{}{}",
+        &base_url[..scheme_end],
+        userinfo,
+        percent_encode_password(password),
+        &authority[at..]
+    ))
+}
+
 /// Resolve the `(engine, url)` pair the DB layer needs to open a connection.
 ///
-/// Mirrors [`crate::helpers::check_if_db_env_is_set_or_set_from_config`]:
-/// - `postgres` -> the `db_pg_host` configured in the INI file.
+/// - `postgres` -> the passwordless `db_pg_host` configured in the INI file,
+///   with the password from the `RUSTY_CV_DB_PASSWORD` environment variable
+///   spliced in. The password lives in a local `String` handed straight to the
+///   connection: it is never written into the process environment.
 /// - `sqlite`   -> the `DATABASE_URL` env var when set, otherwise a
 ///   `sqlite://<configured-path>` URL built from the INI config.
 pub fn resolve_db_target(ctx: &AppContext) -> Result<(String, String), Box<dyn std::error::Error>> {
@@ -74,9 +169,10 @@ pub fn resolve_db_target(ctx: &AppContext) -> Result<(String, String), Box<dyn s
 
     match engine.trim() {
         "postgres" => {
-            let url = ctx
+            let base_url = ctx
                 .get_user_input_db_url()
                 .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+            let url = inject_db_password(&base_url, &read_db_password()?)?;
             Ok((engine, url))
         }
         "sqlite" => {
@@ -149,5 +245,189 @@ mod tests {
         let ctx = empty_context();
         let result = get_db_configurations(&ctx);
         assert!(result.is_err());
+    }
+
+    // ─── password injection ──────────────────────────────────────────────────
+
+    fn context_from(config: &str) -> AppContext {
+        let ui = UserInput {
+            action: UserAction::List(FilterArgs::default()),
+            save_to_database: false,
+            view_generated_cv: false,
+            dry_run: false,
+            config_ini: String::new(),
+            engine: "sqlite".to_string(),
+            repo: None,
+            branch: None,
+        };
+        AppContext::new(load_config(config.to_string()), Local::now(), ui)
+    }
+
+    /// Restore the password variable to whatever it was, so a serial test does
+    /// not leak its value into the next one.
+    struct PasswordVar(Option<String>);
+
+    impl PasswordVar {
+        fn capture() -> Self {
+            PasswordVar(std::env::var(DB_PASSWORD_ENV).ok())
+        }
+    }
+
+    impl Drop for PasswordVar {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => std::env::set_var(DB_PASSWORD_ENV, value),
+                None => std::env::remove_var(DB_PASSWORD_ENV),
+            }
+        }
+    }
+
+    fn percent_decode(encoded: &str) -> String {
+        let bytes = encoded.as_bytes();
+        let mut decoded: Vec<u8> = Vec::with_capacity(bytes.len());
+        let mut index = 0;
+
+        while index < bytes.len() {
+            if bytes[index] == b'%' && index + 2 < bytes.len() {
+                let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).unwrap();
+                decoded.push(u8::from_str_radix(hex, 16).unwrap());
+                index += 3;
+            } else {
+                decoded.push(bytes[index]);
+                index += 1;
+            }
+        }
+
+        String::from_utf8(decoded).unwrap()
+    }
+
+    #[test]
+    fn test_inject_db_password_splices_into_the_userinfo() {
+        let url = inject_db_password(
+            "postgres://rusty_cv@nixos-02.caracara-palermo.ts.net/rusty_cv",
+            "s3cret",
+        )
+        .unwrap();
+        assert_eq!(
+            url,
+            "postgres://rusty_cv:s3cret@nixos-02.caracara-palermo.ts.net/rusty_cv"
+        );
+    }
+
+    #[test]
+    fn test_inject_db_password_rejects_a_base_url_that_already_has_one() {
+        let err = inject_db_password("postgres://rusty_cv:old@host/db", "new")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("already carries a password"), "got: {err}");
+        assert!(err.contains("db_pg_host"), "got: {err}");
+        assert!(err.contains(DB_PASSWORD_ENV), "got: {err}");
+    }
+
+    #[test]
+    fn test_inject_db_password_rejects_a_base_url_without_a_user() {
+        for base in [
+            "postgres://host/db",
+            "postgres://@host/db",
+            "postgres://host/db@path",
+            "not-a-url",
+        ] {
+            let err = inject_db_password(base, "s3cret").unwrap_err().to_string();
+            assert!(err.contains("names no user"), "for {base}, got: {err}");
+        }
+    }
+
+    #[test]
+    fn test_inject_db_password_percent_encodes_every_significant_character() {
+        let password = "p@ss:w/rd#?%";
+        let url = inject_db_password("postgres://rusty_cv@host/db", password).unwrap();
+
+        let userinfo = url
+            .strip_prefix("postgres://")
+            .unwrap()
+            .split('@')
+            .next()
+            .unwrap();
+        let (user, encoded) = userinfo.split_once(':').unwrap();
+
+        assert_eq!(user, "rusty_cv");
+        assert_eq!(percent_decode(encoded), password);
+        assert_eq!(url, "postgres://rusty_cv:p%40ss%3Aw%2Frd%23%3F%25@host/db");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_db_target_postgres_errors_when_the_password_is_unset() {
+        let _restore = PasswordVar::capture();
+        std::env::remove_var(DB_PASSWORD_ENV);
+
+        let ctx = context_from(
+            "[db]\nengine = \"postgres\"\ndb_pg_host = \"postgres://rusty_cv@host/rusty_cv\"",
+        );
+        let err = resolve_db_target(&ctx).unwrap_err().to_string();
+
+        assert!(err.contains(DB_PASSWORD_ENV), "got: {err}");
+        assert!(err.contains("sops"), "got: {err}");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_db_target_postgres_errors_when_the_password_is_empty() {
+        let _restore = PasswordVar::capture();
+        std::env::set_var(DB_PASSWORD_ENV, "   ");
+
+        let ctx = context_from(
+            "[db]\nengine = \"postgres\"\ndb_pg_host = \"postgres://rusty_cv@host/rusty_cv\"",
+        );
+        let err = resolve_db_target(&ctx).unwrap_err().to_string();
+
+        assert!(err.contains(DB_PASSWORD_ENV), "got: {err}");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_db_target_resolves_the_documented_quoted_config() {
+        let _restore = PasswordVar::capture();
+        std::env::set_var(DB_PASSWORD_ENV, "s3cret");
+
+        let ctx = context_from(
+            "[db]\nengine = \"postgres\"\n\
+             db_pg_host = \"postgres://rusty_cv@nixos-02.caracara-palermo.ts.net/rusty_cv\"",
+        );
+        let (engine, url) = resolve_db_target(&ctx).unwrap();
+
+        assert_eq!(engine, "postgres");
+        assert_eq!(
+            url,
+            "postgres://rusty_cv:s3cret@nixos-02.caracara-palermo.ts.net/rusty_cv"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolve_db_target_sqlite_is_unaffected_by_the_password_variable() {
+        let _restore = PasswordVar::capture();
+        let original_url = std::env::var("DATABASE_URL").ok();
+        std::env::remove_var("DATABASE_URL");
+
+        let ctx = context_from(
+            "[db]\nengine = \"sqlite\"\ndb_path = \"/tmp\"\ndb_file = \"test.db\"\n\
+             db_pg_host = \"postgres://rusty_cv@host/rusty_cv\"",
+        );
+
+        std::env::remove_var(DB_PASSWORD_ENV);
+        let without = resolve_db_target(&ctx).unwrap();
+        std::env::set_var(DB_PASSWORD_ENV, "s3cret");
+        let with = resolve_db_target(&ctx).unwrap();
+
+        if let Some(url) = original_url {
+            std::env::set_var("DATABASE_URL", url);
+        }
+
+        assert_eq!(
+            without,
+            ("sqlite".to_string(), "sqlite:///tmp/test.db".to_string())
+        );
+        assert_eq!(without, with);
     }
 }

--- a/src/config_parse.rs
+++ b/src/config_parse.rs
@@ -122,6 +122,25 @@ fn percent_encode_password(password: &str) -> String {
 /// driver error into an actionable one.
 const POSTGRES_URI_SCHEMES: [&str; 2] = ["postgres", "postgresql"];
 
+/// Does this URL carry a password as a query parameter?
+///
+/// PostgreSQL accepts `?password=` as well as userinfo, and prefers it over
+/// the value spliced into the userinfo - so without this check a config-file
+/// password would silently override the sops-supplied one, be invisible to the
+/// credential scan, and survive the redaction (which only knows the
+/// environment's value).
+fn has_password_query_parameter(url: &str) -> bool {
+    let Some((_, query)) = url.split_once('?') else {
+        return false;
+    };
+
+    query.split('&').any(|parameter| {
+        parameter
+            .split_once('=')
+            .is_some_and(|(key, value)| key.eq_ignore_ascii_case("password") && !value.is_empty())
+    })
+}
+
 /// Splice `password` into the userinfo of a passwordless `base_url`.
 ///
 /// The base URL names the database user and carries no password:
@@ -165,7 +184,7 @@ fn inject_db_password(
     }
 
     let userinfo = &authority[..at];
-    if userinfo.contains(':') {
+    if userinfo.contains(':') || has_password_query_parameter(base_url) {
         return Err(format!(
             "The configured database URL already carries a password.\n  \
              Remove the password from db_pg_host in the INI config file: it now comes \
@@ -228,9 +247,12 @@ fn redact_secret(message: &str, secret: &str) -> String {
         return message.to_string();
     }
 
+    // Encoded form first: it is the longer of the two and contains the raw
+    // form's characters, so replacing raw first would shred it into fragments
+    // (a secret of "%" would turn "%2F" into "<marker>2F").
     message
-        .replace(secret, MARKER)
         .replace(&percent_encode_password(secret), MARKER)
+        .replace(secret, MARKER)
 }
 
 /// Open the database connection for this run, with the password scrubbed from
@@ -578,6 +600,41 @@ mod tests {
             "encoded form survived: {redacted}"
         );
         assert_eq!(redacted.matches("<password redacted>").count(), 2);
+    }
+
+    #[test]
+    fn test_inject_db_password_rejects_a_password_query_parameter() {
+        // PostgreSQL prefers this form over the spliced userinfo, so accepting
+        // it would let a config-file password silently beat the sops one.
+        // Assembled at runtime: the credential scanner reads this file too, and
+        // a spelled-out query credential here is exactly what it must flag.
+        let key = "password";
+        for query in [
+            format!("?{key}=fromconfig"),
+            format!("?sslmode=require&{key}=fromconfig"),
+            format!("?{}=fromconfig", key.to_uppercase()),
+        ] {
+            let base = format!("postgres://rusty_cv@host/db{query}");
+            let err = inject_db_password(&base, "s3cret").unwrap_err().to_string();
+            assert!(
+                err.contains("already carries a password"),
+                "for {base}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_inject_db_password_keeps_harmless_query_parameters() {
+        let url = inject_db_password(
+            "postgres://rusty_cv@host/db?sslmode=require&connect_timeout=5",
+            "s3cret",
+        )
+        .unwrap();
+
+        assert!(
+            url.ends_with("?sslmode=require&connect_timeout=5"),
+            "got: {url}"
+        );
     }
 
     #[test]

--- a/src/cv_insert.rs
+++ b/src/cv_insert.rs
@@ -1,9 +1,9 @@
 use crate::command_runner::SystemRunner;
-use crate::config_parse::resolve_db_target;
+use crate::config_parse::connect_db;
 use crate::global_conf::AppContext;
 use crate::prepare_cv;
 use log::{error, info, warn};
-use rusty_cv_creator::database::{DbConnection, establish_connection, save_new_cv_to_db};
+use rusty_cv_creator::database::{DbConnection, save_new_cv_to_db};
 use rusty_cv_creator::models::Cv;
 
 pub fn insert_cv(ctx: &AppContext) -> Result<String, Box<dyn std::error::Error>> {
@@ -30,10 +30,7 @@ pub fn insert_cv(ctx: &AppContext) -> Result<String, Box<dyn std::error::Error>>
     // level: at `warn!` a failed save printed nothing at all.
     if let Err(e) = run_persistence(
         save_to_db,
-        || {
-            let (engine, url) = resolve_db_target(ctx)?;
-            establish_connection(&engine, &url)
-        },
+        || connect_db(ctx),
         &destination_cv_file_full_path,
         &job_title,
         &company_name,

--- a/src/cv_insert.rs
+++ b/src/cv_insert.rs
@@ -2,7 +2,7 @@ use crate::command_runner::SystemRunner;
 use crate::config_parse::resolve_db_target;
 use crate::global_conf::AppContext;
 use crate::prepare_cv;
-use log::{info, warn};
+use log::{error, info, warn};
 use rusty_cv_creator::database::{DbConnection, establish_connection, save_new_cv_to_db};
 use rusty_cv_creator::models::Cv;
 
@@ -25,7 +25,9 @@ pub fn insert_cv(ctx: &AppContext) -> Result<String, Box<dyn std::error::Error>>
     let save_to_db = ctx.get_user_input_save_to_db();
     let application_date = ctx.get_today_str();
 
-    // A failed DB save must not discard a successfully generated CV — log and continue.
+    // A failed DB save must not discard a successfully generated CV — report and
+    // continue. Reported at `error!` so it is visible at env_logger's default
+    // level: at `warn!` a failed save printed nothing at all.
     if let Err(e) = run_persistence(
         save_to_db,
         || {
@@ -38,7 +40,7 @@ pub fn insert_cv(ctx: &AppContext) -> Result<String, Box<dyn std::error::Error>>
         quote.as_ref(),
         &application_date,
     ) {
-        warn!("Could not save CV to database: {e:}");
+        error!("The CV was generated but NOT saved to the database: {e:}");
     }
 
     Ok(destination_cv_file_full_path)

--- a/src/db_url.rs
+++ b/src/db_url.rs
@@ -53,8 +53,10 @@ fn percent_decode(text: &str) -> String {
 ///   a passwordless fallback arrived at through config alone;
 /// - it does not enumerate exact names. Any decoded name CONTAINING
 ///   "password" is treated as password-bearing, which covers `sslpassword` and
-///   whatever the next one turns out to be. No legitimate PostgreSQL parameter
-///   name contains that substring.
+///   whatever the next one turns out to be. Deliberately over-broad: of the
+///   41 parameters libpq accepts, exactly two contain that substring
+///   (`password` and `sslpassword`) and both are secret-bearing, so the width
+///   costs nothing today and covers a name that does not exist yet.
 pub fn has_password_query_parameter(url: &str) -> bool {
     let Some((_, query)) = url.split_once('?') else {
         return false;

--- a/src/db_url.rs
+++ b/src/db_url.rs
@@ -1,0 +1,161 @@
+//! Recognising a password inside a PostgreSQL connection URL.
+//!
+//! Lives in the library crate so the program and the tracked-tree credential
+//! scan share ONE implementation. They were written twice, and both copies had
+//! the same blind spot - a percent-encoded parameter name - which is precisely
+//! the drift a single implementation prevents.
+
+/// Percent-decode `text`, leaving malformed escapes as written.
+///
+/// Only used to compare a query-parameter NAME against the names PostgreSQL
+/// understands, so a lossy decode is the right shape: an escape that does not
+/// parse cannot be a name we care about, and passing it through unchanged is
+/// safe for that comparison.
+fn percent_decode(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        let escape = (bytes[index] == b'%' && index + 2 < bytes.len())
+            .then(|| std::str::from_utf8(&bytes[index + 1..index + 3]).ok())
+            .flatten()
+            .and_then(|hex| u8::from_str_radix(hex, 16).ok());
+
+        match escape {
+            Some(byte) => {
+                decoded.push(byte);
+                index += 3;
+            }
+            None => {
+                decoded.push(bytes[index]);
+                index += 1;
+            }
+        }
+    }
+
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+/// Does this connection URL carry a password in its query string?
+///
+/// PostgreSQL accepts a password as a query parameter as well as in the
+/// userinfo, and prefers the query form - so a config using it would silently
+/// beat the password supplied from the environment.
+///
+/// Three things this deliberately does NOT do, each learned from a real miss:
+///
+/// - it does not compare the raw parameter name. libpq percent-decodes the
+///   name before looking it up, so `%70assword=` is honoured on the wire while
+///   a raw comparison sees nothing;
+/// - it does not require a value. An empty `password=` is accepted by libpq,
+///   which then discards the spliced password and falls through to `.pgpass` -
+///   a passwordless fallback arrived at through config alone;
+/// - it does not enumerate exact names. Any decoded name CONTAINING
+///   "password" is treated as password-bearing, which covers `sslpassword` and
+///   whatever the next one turns out to be. No legitimate PostgreSQL parameter
+///   name contains that substring.
+pub fn has_password_query_parameter(url: &str) -> bool {
+    let Some((_, query)) = url.split_once('?') else {
+        return false;
+    };
+
+    query.split(['&', ';']).any(|parameter| {
+        let name = parameter
+            .split_once('=')
+            .map_or(parameter, |(name, _)| name);
+        percent_decode(name)
+            .to_ascii_lowercase()
+            .contains("password")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Query strings are assembled at runtime: the credential scan reads this
+    /// file too, and a spelled-out one is exactly what it must flag.
+    fn url_with(query: &str) -> String {
+        format!("postgres://rusty_cv@host/db?{query}")
+    }
+
+    #[test]
+    fn plain_password_parameter_is_recognised() {
+        assert!(has_password_query_parameter(&url_with(&format!(
+            "{}=secret",
+            "password"
+        ))));
+    }
+
+    #[test]
+    fn percent_encoded_parameter_names_are_recognised() {
+        // libpq decodes the NAME before looking it up, so every spelling below
+        // reaches the server as a password.
+        for name in ["%70assword", "pass%77ord", "passwor%64", "%70%61ssword"] {
+            assert!(
+                has_password_query_parameter(&url_with(&format!("{name}=secret"))),
+                "missed {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_password_parameter_is_recognised() {
+        // libpq stores the empty password, discards the spliced one and falls
+        // through to .pgpass - a passwordless fallback reached through config.
+        assert!(has_password_query_parameter(&url_with(&format!(
+            "{}=",
+            "password"
+        ))));
+        assert!(has_password_query_parameter(&url_with("password")));
+    }
+
+    #[test]
+    fn other_password_bearing_names_are_recognised() {
+        assert!(has_password_query_parameter(&url_with(&format!(
+            "ssl{}=secret",
+            "password"
+        ))));
+    }
+
+    #[test]
+    fn it_is_found_in_any_parameter_position() {
+        assert!(has_password_query_parameter(&url_with(&format!(
+            "sslmode=require&connect_timeout=5&{}=secret",
+            "password"
+        ))));
+    }
+
+    #[test]
+    fn legitimate_parameters_are_left_alone() {
+        for query in [
+            "sslmode=require",
+            "connect_timeout=5",
+            "application_name=rusty_cv",
+            "sslmode=require&connect_timeout=5",
+            "sslcert=/tmp/c.pem&sslkey=/tmp/k.pem",
+            "passfile=/home/user/.pgpass",
+        ] {
+            assert!(
+                !has_password_query_parameter(&url_with(query)),
+                "false positive on {query}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_url_without_a_query_has_none() {
+        assert!(!has_password_query_parameter(
+            "postgres://rusty_cv@host/rusty_cv"
+        ));
+    }
+
+    #[test]
+    fn percent_decode_leaves_malformed_escapes_as_written() {
+        assert_eq!(percent_decode("%70assword"), "password");
+        assert_eq!(percent_decode("%zz"), "%zz");
+        assert_eq!(percent_decode("%7"), "%7");
+        assert_eq!(percent_decode("plain"), "plain");
+    }
+}

--- a/src/file_handlers.rs
+++ b/src/file_handlers.rs
@@ -736,7 +736,7 @@ mod tests {
     /// disabled (`core.hooksPath` pointed at an empty dir) so the developer's
     /// global git hooks cannot interfere with the hermetic fixture.
     fn git_in(dir: &Path, empty_hooks: &Path, args: &[&str]) {
-        let ok = rusty_cv_creator::child_env::command_without_db_password("git")
+        let ok = rusty_cv_creator::child_env::command_without_db_credentials("git")
             .current_dir(dir)
             .arg("-c")
             .arg(format!("core.hooksPath={}", empty_hooks.display()))

--- a/src/file_handlers.rs
+++ b/src/file_handlers.rs
@@ -736,7 +736,7 @@ mod tests {
     /// disabled (`core.hooksPath` pointed at an empty dir) so the developer's
     /// global git hooks cannot interfere with the hermetic fixture.
     fn git_in(dir: &Path, empty_hooks: &Path, args: &[&str]) {
-        let ok = std::process::Command::new("git")
+        let ok = rusty_cv_creator::child_env::command_without_db_password("git")
             .current_dir(dir)
             .arg("-c")
             .arg(format!("core.hooksPath={}", empty_hooks.display()))

--- a/src/global_conf.rs
+++ b/src/global_conf.rs
@@ -1,6 +1,7 @@
 use crate::{
     UserInput,
     cli_structure::{FilterArgs, UserAction},
+    helpers::clean_string_from_quotes,
 };
 use chrono::{DateTime, Local};
 use configparser::ini::Ini;
@@ -134,13 +135,22 @@ impl AppContext {
         self.get_user_input().save_to_database
     }
 
+    /// The `[db] engine` value, stripped of the surrounding quotes the
+    /// documented config format uses (`engine = "postgres"`). Without the
+    /// stripping the engine name never matches `postgres`/`sqlite` and the
+    /// caller falls through to its catch-all arm.
     pub fn get_user_input_db_engine(&self) -> Result<String, Box<dyn std::error::Error>> {
-        self.get_user_input_vars("db", "engine")
+        let engine = self.get_user_input_vars("db", "engine")?;
+        Ok(clean_string_from_quotes(&engine))
     }
 
+    /// The `[db] db_pg_host` value, stripped of the surrounding quotes the
+    /// documented config format uses. The value is a passwordless base URL —
+    /// the password is spliced in at connection time from the environment.
     pub fn get_user_input_db_url(&self) -> Result<String, &str> {
         self.config
             .get("db", "db_pg_host")
+            .map(|url| clean_string_from_quotes(&url))
             .ok_or("Could not get the database engine")
     }
 }
@@ -201,6 +211,43 @@ mod tests {
     fn test_get_user_input_vars_errors_when_missing() {
         let ctx = context();
         assert!(ctx.get_user_input_vars("missing", "key").is_err());
+    }
+
+    #[test]
+    fn test_db_accessors_strip_the_quotes_of_the_documented_format() {
+        // The documented config format quotes every value; without stripping,
+        // the engine never matches "postgres" and the URL keeps its quotes.
+        let mut ini = Ini::new();
+        ini.set("db", "engine", Some("\"postgres\"".to_string()));
+        ini.set(
+            "db",
+            "db_pg_host",
+            Some("\"postgres://rusty_cv@example.invalid/rusty_cv\"".to_string()),
+        );
+        let ctx = AppContext::new(ini, Local::now(), dummy_user_input());
+
+        assert_eq!(ctx.get_user_input_db_engine().unwrap(), "postgres");
+        assert_eq!(
+            ctx.get_user_input_db_url().unwrap(),
+            "postgres://rusty_cv@example.invalid/rusty_cv"
+        );
+    }
+
+    #[test]
+    fn test_db_accessors_leave_unquoted_values_untouched() {
+        let mut ini = Ini::new();
+        ini.set("db", "engine", Some("sqlite".to_string()));
+        ini.set("db", "db_pg_host", Some("postgres://u@h/d".to_string()));
+        let ctx = AppContext::new(ini, Local::now(), dummy_user_input());
+
+        assert_eq!(ctx.get_user_input_db_engine().unwrap(), "sqlite");
+        assert_eq!(ctx.get_user_input_db_url().unwrap(), "postgres://u@h/d");
+    }
+
+    #[test]
+    fn test_get_user_input_db_url_errors_when_missing() {
+        let ctx = context();
+        assert!(ctx.get_user_input_db_url().is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod child_env;
 pub mod database;
+pub mod db_url;
 pub mod models;
 pub mod schema;
 pub mod tui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
+pub mod child_env;
 pub mod database;
 pub mod models;
 pub mod schema;

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1,4 +1,4 @@
-use crate::child_env::command_without_db_password;
+use crate::child_env::command_without_db_credentials;
 use crate::tui::state::AppState;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::path::Path;
@@ -54,7 +54,7 @@ pub fn handle_key_event(
 ///
 /// `xdg-open` starts a long-lived desktop application (often a browser) that
 /// keeps its environment for the whole session, so the child is built through
-/// `command_without_db_password`.
+/// `command_without_db_credentials`.
 pub fn open_pdf(path: &str) -> Result<(), String> {
     if path.is_empty() {
         return Err(format!("File not found: {path}"));
@@ -64,12 +64,12 @@ pub fn open_pdf(path: &str) -> Result<(), String> {
         return Err(format!("File not found: {path}"));
     }
     #[cfg(target_os = "macos")]
-    command_without_db_password("open")
+    command_without_db_credentials("open")
         .arg(path)
         .spawn()
         .map_err(|e| format!("Failed to open {path}: {e}"))?;
     #[cfg(target_os = "linux")]
-    command_without_db_password("xdg-open")
+    command_without_db_credentials("xdg-open")
         .arg(path)
         .spawn()
         .map_err(|e| format!("Failed to open {path}: {e}"))?;

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1,7 +1,7 @@
+use crate::child_env::command_without_db_password;
 use crate::tui::state::AppState;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::path::Path;
-use std::process::Command;
 
 /// Returns Ok(true) to signal quit, Ok(false) to continue.
 pub fn handle_key_event(
@@ -51,6 +51,10 @@ pub fn handle_key_event(
 
 /// Open `path` in the OS default viewer (non-blocking).
 /// Returns Err("File not found: {path}") when the file does not exist, is empty, or is a directory.
+///
+/// `xdg-open` starts a long-lived desktop application (often a browser) that
+/// keeps its environment for the whole session, so the child is built through
+/// `command_without_db_password`.
 pub fn open_pdf(path: &str) -> Result<(), String> {
     if path.is_empty() {
         return Err(format!("File not found: {path}"));
@@ -60,12 +64,12 @@ pub fn open_pdf(path: &str) -> Result<(), String> {
         return Err(format!("File not found: {path}"));
     }
     #[cfg(target_os = "macos")]
-    Command::new("open")
+    command_without_db_password("open")
         .arg(path)
         .spawn()
         .map_err(|e| format!("Failed to open {path}: {e}"))?;
     #[cfg(target_os = "linux")]
-    Command::new("xdg-open")
+    command_without_db_password("xdg-open")
         .arg(path)
         .spawn()
         .map_err(|e| format!("Failed to open {path}: {e}"))?;

--- a/src/user_action.rs
+++ b/src/user_action.rs
@@ -1,11 +1,11 @@
 use crate::cli_structure::FilterArgs;
-use crate::config_parse::resolve_db_target;
+use crate::config_parse::connect_db;
 use crate::file_handlers;
 use crate::global_conf::AppContext;
 use crate::helpers::my_fzf;
 use diesel::prelude::*;
 use log::{error, info, warn};
-use rusty_cv_creator::database::{DbConnection, establish_connection, read_cv_paths};
+use rusty_cv_creator::database::{DbConnection, read_cv_paths};
 use std::path::Path;
 
 pub fn show_cvs(
@@ -21,8 +21,7 @@ pub fn show_cvs(
 pub fn remove_cv(ctx: &AppContext, filters: &FilterArgs) -> Result<(), Box<dyn std::error::Error>> {
     use rusty_cv_creator::schema::cv::dsl::{cv, pdf_cv_path};
 
-    let (engine, url) = resolve_db_target(ctx)?;
-    let mut conn = establish_connection(&engine, &url)?;
+    let mut conn = connect_db(ctx)?;
 
     let cv_remove = show_cvs(&mut conn, filters)?;
 

--- a/tests/child_env_scrubbing.rs
+++ b/tests/child_env_scrubbing.rs
@@ -1,0 +1,78 @@
+//! The database password must not survive into a child process.
+//!
+//! A child inherits the whole environment by default. The PDF viewer, the
+//! browser `xdg-open` starts, `git`, `sudo` and `tailscale` would each hold the
+//! password in `/proc/<pid>/environ` for their entire lifetime - and a desktop
+//! browser's lifetime is the whole session. `command_without_db_password` is
+//! the one constructor that strips it; these tests are its proof.
+
+use rusty_cv_creator::child_env::{DB_PASSWORD_ENV, command_without_db_password};
+use serial_test::serial;
+
+/// Not a credential shape: no scheme, no userinfo. The scanner in
+/// `db_credentials_regression.rs` reads this file like any other.
+const SENTINEL: &str = "sentinel-value-that-is-not-a-real-password";
+
+fn child_environment(mut command: std::process::Command) -> String {
+    let out = command
+        .args(["-c", "env"])
+        .output()
+        .expect("spawning `sh -c env` should work on any supported platform");
+    assert!(out.status.success(), "`sh -c env` failed in the child");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+#[serial]
+fn the_database_password_never_reaches_a_child_environment() {
+    // Mutates process environment, hence `#[serial]`.
+    set_password_in_this_process(SENTINEL);
+
+    let scrubbed = child_environment(command_without_db_password("sh"));
+
+    assert!(
+        !scrubbed.contains(DB_PASSWORD_ENV),
+        "the child still sees {DB_PASSWORD_ENV} in its environment"
+    );
+    assert!(
+        !scrubbed.contains(SENTINEL),
+        "the child still sees the password value in its environment"
+    );
+
+    // The parent keeps it: this program needs the password to connect. Only the
+    // children are stripped.
+    assert_eq!(
+        std::env::var(DB_PASSWORD_ENV).ok().as_deref(),
+        Some(SENTINEL),
+        "scrubbing a child must not disturb this process's own environment"
+    );
+
+    clear_password();
+}
+
+#[test]
+#[serial]
+fn an_unscrubbed_child_does_inherit_it_so_the_assertion_is_not_vacuous() {
+    // Control. Without the constructor the password is inherited - which is
+    // exactly the defect. If this ever stops holding, the test above proves
+    // nothing and must be re-examined rather than trusted.
+    set_password_in_this_process(SENTINEL);
+
+    let inherited = child_environment(std::process::Command::new("sh"));
+
+    assert!(
+        inherited.contains(SENTINEL),
+        "a plain `Command::new` child is expected to inherit the environment; \
+         if it no longer does, the scrubbing test above is vacuous"
+    );
+
+    clear_password();
+}
+
+fn set_password_in_this_process(value: &str) {
+    std::env::set_var(DB_PASSWORD_ENV, value);
+}
+
+fn clear_password() {
+    std::env::remove_var(DB_PASSWORD_ENV);
+}

--- a/tests/child_env_scrubbing.rs
+++ b/tests/child_env_scrubbing.rs
@@ -1,17 +1,30 @@
-//! The database password must not survive into a child process.
+//! The database credentials must not survive into a child process.
 //!
 //! A child inherits the whole environment by default. The PDF viewer, the
 //! browser `xdg-open` starts, `git`, `sudo` and `tailscale` would each hold the
-//! password in `/proc/<pid>/environ` for their entire lifetime - and a desktop
-//! browser's lifetime is the whole session. `command_without_db_password` is
-//! the one constructor that strips it; these tests are its proof.
+//! credentials in `/proc/<pid>/environ` for their entire lifetime - and a
+//! desktop browser's lifetime is the whole session.
+//! `command_without_db_credentials` is the one constructor that strips them;
+//! these tests are its proof.
+//!
+//! Two variables carry a secret, not one. `RUSTY_CV_DB_PASSWORD` is the
+//! deliberate delivery mechanism. `DATABASE_URL` is written into this process's
+//! own environment at startup from the configured `db_pg_host`, and a config
+//! whose URL still carries inline userinfo puts a password there too - which is
+//! exactly the state of a config that has not been migrated yet.
 
-use rusty_cv_creator::child_env::{DB_PASSWORD_ENV, command_without_db_password};
+use rusty_cv_creator::child_env::{DB_PASSWORD_ENV, DB_URL_ENV, command_without_db_credentials};
 use serial_test::serial;
 
 /// Not a credential shape: no scheme, no userinfo. The scanner in
 /// `db_credentials_regression.rs` reads this file like any other.
 const SENTINEL: &str = "sentinel-value-that-is-not-a-real-password";
+
+/// A URL carrying inline userinfo, assembled at runtime so this source file
+/// holds no credential-shaped literal for the scanner to flag.
+fn url_with_inline_credentials() -> String {
+    format!("postgres://sentinel-user{}{SENTINEL}@localhost/db", ':')
+}
 
 fn child_environment(mut command: std::process::Command) -> String {
     let out = command
@@ -24,55 +37,89 @@ fn child_environment(mut command: std::process::Command) -> String {
 
 #[test]
 #[serial]
-fn the_database_password_never_reaches_a_child_environment() {
+fn neither_credential_variable_reaches_a_child_environment() {
     // Mutates process environment, hence `#[serial]`.
-    set_password_in_this_process(SENTINEL);
+    let _guard = CredentialEnvGuard::set(SENTINEL, &url_with_inline_credentials());
 
-    let scrubbed = child_environment(command_without_db_password("sh"));
+    let scrubbed = child_environment(command_without_db_credentials("sh"));
 
     assert!(
         !scrubbed.contains(DB_PASSWORD_ENV),
         "the child still sees {DB_PASSWORD_ENV} in its environment"
     );
     assert!(
+        !scrubbed.contains(DB_URL_ENV),
+        "the child still sees {DB_URL_ENV} in its environment"
+    );
+    assert!(
         !scrubbed.contains(SENTINEL),
-        "the child still sees the password value in its environment"
+        "the child still sees a password value in its environment"
     );
 
-    // The parent keeps it: this program needs the password to connect. Only the
+    // The parent keeps both: this program needs them to connect. Only the
     // children are stripped.
     assert_eq!(
         std::env::var(DB_PASSWORD_ENV).ok().as_deref(),
         Some(SENTINEL),
         "scrubbing a child must not disturb this process's own environment"
     );
-
-    clear_password();
+    assert_eq!(
+        std::env::var(DB_URL_ENV).ok(),
+        Some(url_with_inline_credentials()),
+        "scrubbing a child must not disturb this process's own environment"
+    );
 }
 
 #[test]
 #[serial]
-fn an_unscrubbed_child_does_inherit_it_so_the_assertion_is_not_vacuous() {
-    // Control. Without the constructor the password is inherited - which is
+fn an_unscrubbed_child_inherits_them_so_the_assertions_are_not_vacuous() {
+    // Control. Without the constructor both variables are inherited - which is
     // exactly the defect. If this ever stops holding, the test above proves
     // nothing and must be re-examined rather than trusted.
-    set_password_in_this_process(SENTINEL);
+    let _guard = CredentialEnvGuard::set(SENTINEL, &url_with_inline_credentials());
 
     let inherited = child_environment(std::process::Command::new("sh"));
 
     assert!(
-        inherited.contains(SENTINEL),
-        "a plain `Command::new` child is expected to inherit the environment; \
+        inherited.contains(DB_PASSWORD_ENV),
+        "a plain `Command::new` child is expected to inherit {DB_PASSWORD_ENV}; \
          if it no longer does, the scrubbing test above is vacuous"
     );
-
-    clear_password();
+    assert!(
+        inherited.contains(DB_URL_ENV),
+        "a plain `Command::new` child is expected to inherit {DB_URL_ENV}; \
+         if it no longer does, the scrubbing test above is vacuous"
+    );
 }
 
-fn set_password_in_this_process(value: &str) {
-    std::env::set_var(DB_PASSWORD_ENV, value);
+/// Restores both variables on drop, so a panicking assertion cannot leak the
+/// sentinel into a sibling test under threaded `cargo test`.
+struct CredentialEnvGuard {
+    password: Option<String>,
+    url: Option<String>,
 }
 
-fn clear_password() {
-    std::env::remove_var(DB_PASSWORD_ENV);
+impl CredentialEnvGuard {
+    fn set(password: &str, url: &str) -> Self {
+        let guard = Self {
+            password: std::env::var(DB_PASSWORD_ENV).ok(),
+            url: std::env::var(DB_URL_ENV).ok(),
+        };
+        std::env::set_var(DB_PASSWORD_ENV, password);
+        std::env::set_var(DB_URL_ENV, url);
+        guard
+    }
+}
+
+impl Drop for CredentialEnvGuard {
+    fn drop(&mut self) {
+        match &self.password {
+            Some(value) => std::env::set_var(DB_PASSWORD_ENV, value),
+            None => std::env::remove_var(DB_PASSWORD_ENV),
+        }
+        match &self.url {
+            Some(value) => std::env::set_var(DB_URL_ENV, value),
+            None => std::env::remove_var(DB_URL_ENV),
+        }
+    }
 }

--- a/tests/db_credentials_regression.rs
+++ b/tests/db_credentials_regression.rs
@@ -124,7 +124,7 @@ fn has_inline_credential(line: &str) -> bool {
             }
         }
 
-        if has_password_query_parameter(authority) {
+        if rusty_cv_creator::db_url::has_password_query_parameter(authority) {
             return true;
         }
 
@@ -132,28 +132,6 @@ fn has_inline_credential(line: &str) -> bool {
     }
 
     false
-}
-
-/// A password can also ride in the URL's query string, which PostgreSQL
-/// accepts and prefers over the one spliced into the userinfo. That form
-/// carries no colon before the `@`, so the userinfo matcher above is blind to
-/// it - it needs its own check or a plaintext credential ships undetected.
-fn has_password_query_parameter(url_tail: &str) -> bool {
-    let url = url_tail
-        .split_whitespace()
-        .next()
-        .unwrap_or_default()
-        .trim_end_matches(['"', '\'', ',', ';', ')']);
-
-    let Some(query) = url.split_once('?').map(|(_, query)| query) else {
-        return false;
-    };
-
-    query.split('&').any(|parameter| {
-        parameter
-            .split_once('=')
-            .is_some_and(|(key, value)| key.eq_ignore_ascii_case("password") && !value.is_empty())
-    })
 }
 
 fn hits_in(name: &str, text: &str, hit: &impl Fn(&str) -> bool, found: &mut Vec<String>) {

--- a/tests/db_credentials_regression.rs
+++ b/tests/db_credentials_regression.rs
@@ -107,6 +107,12 @@ fn has_inline_credential(line: &str) -> bool {
         if let (Some(at), Some(colon)) = (authority.find('@'), authority.find(':')) {
             let user = &authority[..colon];
             let password = &authority[colon + 1..at.max(colon + 1)];
+            // Neither segment may contain whitespace. This is a deliberate
+            // trade-off, not an oversight: it is what stops ordinary prose
+            // ("see https://host/docs: ask bob@host") from matching, and
+            // `the_matcher_ignores_passwordless_and_pathological_urls` pins
+            // it. The cost is that a passphrase containing a space slips
+            // through - recorded as a known gap in the architecture brief.
             let is_userinfo = colon < at
                 && !user.is_empty()
                 && !password.is_empty()

--- a/tests/db_credentials_regression.rs
+++ b/tests/db_credentials_regression.rs
@@ -8,9 +8,22 @@
 //! targets from `tests/*.rs` only, so `tests/regression/db_credentials.rs`
 //! would never be compiled or run.
 //!
-//! There is NO allowlist. If a scan hit is legitimate, the fixture gets fixed,
-//! not the scanner. That is also why every credential-shaped string in this
-//! file is assembled at runtime from fragments: the scanner scans itself.
+//! THE SCANNING RULE, PLAINLY: every tracked file is scanned. The only things
+//! skipped are prose (`.md`, which legitimately describes the credential shape
+//! -- the analysis document on this branch spells the defect out on purpose)
+//! and files whose bytes are not valid UTF-8 (binaries), skipped silently.
+//! Everything else is scanned: `.json`, `.sql`, `.feature`, `.xml`, `.iml`,
+//! `env.sample`, `.envrc`, and extensionless files such as
+//! `.github/CODEOWNERS`.
+//!
+//! There is NO allowlist, and there never will be one. An allowlist is what
+//! made `env.sample` -- the file a human copies to `.env` and pastes a real
+//! password into -- invisible to the previous version of this scanner. When
+//! this test hits, the offending FILE gets fixed; the scanner is never narrowed
+//! to make a hit go away. If a legitimate example needs a credential-shaped
+//! string, assemble it at runtime from fragments, the way the tests below do.
+//! That is also why every credential-shaped string in this file is assembled at
+//! runtime: the scanner scans itself.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -20,11 +33,6 @@ use std::process::Command;
 fn burned_literal() -> String {
     ["rusty", "cv", "01"].join("-")
 }
-
-/// Machine-read file kinds where a credential is dangerous. Markdown and other
-/// prose are deliberately excluded from the shape scan: the analysis document
-/// legitimately describes the defect shape.
-const SCANNED_EXTENSIONS: [&str; 7] = ["nix", "ini", "toml", "rs", "yml", "yaml", "sh"];
 
 /// Every file tracked by git, as absolute paths, paired with their repo-relative
 /// name for reporting. Fails loudly when git is unavailable: a scanner that
@@ -59,31 +67,34 @@ fn tracked_files() -> Vec<(String, PathBuf)> {
     files
 }
 
-fn read_text(path: &Path) -> Option<String> {
-    std::fs::read(path)
-        .ok()
-        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
-}
-
-fn is_machine_read_file(name: &str) -> bool {
-    let path = Path::new(name);
-
-    let file_name = path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or_default();
-    if file_name.starts_with(".env") {
-        return true;
-    }
-
-    path.extension()
+/// The one and only exclusion of the shape scan: prose. A `.md` file is allowed
+/// to describe what a leaked credential looks like; that is what documentation
+/// is for. Nothing else is excluded -- there is no extension allowlist.
+fn is_prose(name: &str) -> bool {
+    Path::new(name)
+        .extension()
         .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| SCANNED_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()))
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
 }
 
 /// Structural detection of a password inside a URL userinfo: find `://`, then a
-/// `:` before the next `@`, with that `@` before the next `/`. No regex, so no
-/// new dependency.
+/// `:` before the next `@`. No regex, so no new dependency.
+///
+/// The `@` is deliberately NOT required to precede the first `/`: a password may
+/// legally contain a slash, and requiring the authority to end before the first
+/// `/` made exactly that shape invisible. (The shape is not written out here --
+/// this file is scanned by its own matcher; see the runtime-assembled fixture in
+/// `the_matcher_fires_when_the_password_itself_contains_a_slash`.) The trade is
+/// more false positives -- accepted on purpose, because a false positive gets
+/// the file fixed while a miss gets a password committed.
+///
+/// What this detector still CANNOT see:
+/// - it is line-based, so a credential split across two lines (a wrapped INI
+///   value, a multi-line YAML scalar, a Rust string continued with `\`) evades
+///   it entirely;
+/// - a password held in a variable and interpolated at runtime, which is the
+///   shape the fixtures in this repo deliberately use;
+/// - a credential in a file whose bytes are not valid UTF-8.
 ///
 /// The shape is deliberately not spelled out as a literal anywhere in this
 /// file: once tracked, this file is scanned by its own matcher.
@@ -94,11 +105,9 @@ fn has_inline_credential(line: &str) -> bool {
         let authority = &rest[scheme + "://".len()..];
 
         if let (Some(at), Some(colon)) = (authority.find('@'), authority.find(':')) {
-            let ends_before_path = authority.find('/').is_none_or(|slash| at < slash);
             let user = &authority[..colon];
             let password = &authority[colon + 1..at.max(colon + 1)];
             let is_userinfo = colon < at
-                && ends_before_path
                 && !user.is_empty()
                 && !password.is_empty()
                 && !user.contains(char::is_whitespace)
@@ -115,37 +124,68 @@ fn has_inline_credential(line: &str) -> bool {
     false
 }
 
-fn offences(hit: impl Fn(&str) -> bool, only_machine_read: bool) -> Vec<String> {
+fn hits_in(name: &str, text: &str, hit: &impl Fn(&str) -> bool, found: &mut Vec<String>) {
+    for (index, line) in text.lines().enumerate() {
+        if hit(line) {
+            found.push(format!("{name}:{}", index + 1));
+        }
+    }
+}
+
+/// Shape scan: EVERY tracked file, minus prose, minus binaries. Not an
+/// allowlist -- a denylist of exactly two entries.
+fn offences_outside_prose(hit: impl Fn(&str) -> bool) -> Vec<String> {
     let mut found = Vec::new();
 
     for (name, path) in tracked_files() {
-        if only_machine_read && !is_machine_read_file(&name) {
+        if is_prose(&name) {
             continue;
         }
 
-        let Some(text) = read_text(&path) else {
+        let Ok(bytes) = std::fs::read(&path) else {
             found.push(format!("{name}: tracked file could not be read"));
             continue;
         };
 
-        for (index, line) in text.lines().enumerate() {
-            if hit(line) {
-                found.push(format!("{name}:{}", index + 1));
-            }
-        }
+        // Not valid UTF-8 => binary => skipped silently, by design.
+        let Ok(text) = String::from_utf8(bytes) else {
+            continue;
+        };
+
+        hits_in(&name, &text, &hit, &mut found);
+    }
+
+    found
+}
+
+/// Literal scan: EVERY tracked file, no exclusions at all -- prose included,
+/// binaries read lossily so a literal buried in one is still caught.
+fn offences_everywhere(hit: impl Fn(&str) -> bool) -> Vec<String> {
+    let mut found = Vec::new();
+
+    for (name, path) in tracked_files() {
+        let Ok(bytes) = std::fs::read(&path) else {
+            found.push(format!("{name}: tracked file could not be read"));
+            continue;
+        };
+
+        let text = String::from_utf8_lossy(&bytes);
+        hits_in(&name, &text, &hit, &mut found);
     }
 
     found
 }
 
 #[test]
-fn no_tracked_machine_read_file_carries_an_inline_credential_url() {
-    let found = offences(has_inline_credential, true);
+fn no_tracked_file_outside_prose_carries_an_inline_credential_url() {
+    let found = offences_outside_prose(has_inline_credential);
 
     assert!(
         found.is_empty(),
         "a URL carrying a password in its userinfo was found in tracked files:\n  {}\n\
-         Remove the credential; the postgres password comes from RUSTY_CV_DB_PASSWORD.",
+         Fix the FILE, never this scanner. Remove the credential; the postgres\n\
+         password comes from RUSTY_CV_DB_PASSWORD. If the string is a legitimate\n\
+         example, assemble it at runtime from fragments.",
         found.join("\n  ")
     );
 }
@@ -153,7 +193,7 @@ fn no_tracked_machine_read_file_carries_an_inline_credential_url() {
 #[test]
 fn the_burned_credential_literal_never_reappears() {
     let literal = burned_literal();
-    let found = offences(|line| line.contains(&literal), false);
+    let found = offences_everywhere(|line| line.contains(&literal));
 
     assert!(
         found.is_empty(),
@@ -175,6 +215,21 @@ fn the_matcher_fires_on_a_known_bad_url() {
 }
 
 #[test]
+fn the_matcher_fires_when_the_password_itself_contains_a_slash() {
+    // The hole the previous matcher had: it demanded the `@` come before the
+    // first `/`, so a slash inside the password hid the whole credential.
+    let scheme = "postgres";
+    let with_slash = format!("db_url = \"{scheme}://user{}pa/ss@host/db\"", ':');
+    assert!(has_inline_credential(&with_slash), "missed: {with_slash}");
+
+    let many_slashes = format!("{scheme}://user{}a/b/c@host/db", ':');
+    assert!(
+        has_inline_credential(&many_slashes),
+        "missed: {many_slashes}"
+    );
+}
+
+#[test]
 fn the_matcher_ignores_passwordless_and_pathological_urls() {
     for clean in [
         "postgres://rusty_cv@nixos-02.caracara-palermo.ts.net/rusty_cv",
@@ -187,23 +242,84 @@ fn the_matcher_ignores_passwordless_and_pathological_urls() {
     }
 }
 
+/// The names the shape scan actually visits, derived exactly the way the scan
+/// derives them -- so the test below proves coverage of the real tracked tree,
+/// not of a hand-written list that can drift away from it.
+fn shape_scanned_names() -> Vec<String> {
+    tracked_files()
+        .into_iter()
+        .map(|(name, _)| name)
+        .filter(|name| !is_prose(name))
+        .collect()
+}
+
 #[test]
-fn the_scanned_set_covers_the_machine_read_file_kinds() {
+fn the_shape_scan_covers_every_tracked_file_except_prose() {
+    let scanned = shape_scanned_names();
+
+    // The proven hole in the extension allowlist this replaced. `env.sample`
+    // exists to be copied to `.env`, which makes it the single most likely
+    // place for a human to paste a real password -- and its name starts with
+    // neither `.env` nor an allowlisted extension, so it was invisible.
+    // `.github/CODEOWNERS` has no extension at all; `.json`, `.sql`,
+    // `.feature` and `.xml` were simply never on the list.
     for name in [
-        "devenv.nix",
-        "rusty-cv-config-example.ini",
-        "Cargo.toml",
-        "src/config_parse.rs",
-        ".github/workflows/build.yml",
-        "scripts/thing.yaml",
-        "scripts/thing.sh",
-        ".env",
-        ".env.testing",
+        "env.sample",
+        ".github/CODEOWNERS",
+        ".envrc",
+        ".idea/rusty_cv_creator.iml",
+        "Cargo.lock",
+        "migrations/.keep",
+        "docs/feature/fix-db-credentials-from-sops/deliver/roadmap.json",
+        "tests/acceptance/template-source/public-source.feature",
     ] {
-        assert!(is_machine_read_file(name), "should be scanned: {name}");
+        assert!(
+            scanned.iter().any(|scanned_name| scanned_name == name),
+            "must be scanned: {name}"
+        );
     }
 
-    for name in ["README.md", "docs/product/architecture/brief.md", "LICENSE"] {
-        assert!(!is_machine_read_file(name), "should not be scanned: {name}");
+    // Prose is the only exclusion, and it is a real one: these files describe
+    // the credential shape on purpose.
+    for name in ["README.md", "docs/product/architecture/brief.md"] {
+        assert!(
+            tracked_files().iter().any(|(tracked, _)| tracked == name),
+            "fixture drifted: {name} is no longer tracked"
+        );
+        assert!(
+            !scanned.iter().any(|scanned_name| scanned_name == name),
+            "prose must not be shape-scanned: {name}"
+        );
+    }
+
+    // And nothing else is excluded. If this fails, an allowlist crept back in.
+    let skipped: Vec<String> = tracked_files()
+        .into_iter()
+        .map(|(name, _)| name)
+        .filter(|name| is_prose(name))
+        .collect();
+    assert!(
+        skipped.iter().all(|name| name.ends_with(".md")),
+        "the only exclusion is `.md` prose, but these were skipped too: {skipped:?}"
+    );
+}
+
+#[test]
+fn the_literal_scan_has_no_exclusions_at_all() {
+    let literal_scanned: Vec<String> = offences_everywhere(|_| true)
+        .into_iter()
+        .filter_map(|hit| hit.rsplit_once(':').map(|(name, _)| name.to_string()))
+        .collect();
+
+    // Prose is scanned here: the analysis document may describe the shape, but
+    // it must never carry the burned literal itself.
+    for name in [
+        "README.md",
+        "docs/feature/fix-db-credentials-from-sops/rca.md",
+    ] {
+        assert!(
+            literal_scanned.iter().any(|scanned| scanned == name),
+            "the literal scan must reach prose too: {name}"
+        );
     }
 }

--- a/tests/db_credentials_regression.rs
+++ b/tests/db_credentials_regression.rs
@@ -1,0 +1,209 @@
+//! Regression scanner: no credential ever lands in a tracked file again.
+//!
+//! A plaintext PostgreSQL password lived in two tracked files for two years
+//! because nothing in the build, the test suite or the pre-commit hooks could
+//! recognise a URL userinfo password. This test is that missing control.
+//!
+//! Placed at the top level of `tests/` on purpose: cargo auto-discovers test
+//! targets from `tests/*.rs` only, so `tests/regression/db_credentials.rs`
+//! would never be compiled or run.
+//!
+//! There is NO allowlist. If a scan hit is legitimate, the fixture gets fixed,
+//! not the scanner. That is also why every credential-shaped string in this
+//! file is assembled at runtime from fragments: the scanner scans itself.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The burned literal: it is in git history forever and must never be re-added.
+/// Assembled at runtime so this file does not carry it.
+fn burned_literal() -> String {
+    ["rusty", "cv", "01"].join("-")
+}
+
+/// Machine-read file kinds where a credential is dangerous. Markdown and other
+/// prose are deliberately excluded from the shape scan: the analysis document
+/// legitimately describes the defect shape.
+const SCANNED_EXTENSIONS: [&str; 7] = ["nix", "ini", "toml", "rs", "yml", "yaml", "sh"];
+
+/// Every file tracked by git, as absolute paths, paired with their repo-relative
+/// name for reporting. Fails loudly when git is unavailable: a scanner that
+/// silently passes is worse than no scanner.
+fn tracked_files() -> Vec<(String, PathBuf)> {
+    let root = env!("CARGO_MANIFEST_DIR");
+
+    let output = Command::new("git")
+        .args(["ls-files", "-z"])
+        .current_dir(root)
+        .output()
+        .unwrap_or_else(|e| panic!("cannot run `git ls-files` in {root}: {e}"));
+
+    assert!(
+        output.status.success(),
+        "`git ls-files` failed in {root}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let listing = String::from_utf8(output.stdout).expect("git ls-files emitted invalid UTF-8");
+    let files: Vec<(String, PathBuf)> = listing
+        .split('\0')
+        .filter(|name| !name.is_empty())
+        .map(|name| (name.to_string(), Path::new(root).join(name)))
+        .collect();
+
+    assert!(
+        !files.is_empty(),
+        "`git ls-files` returned nothing in {root}: the scan would pass vacuously"
+    );
+
+    files
+}
+
+fn read_text(path: &Path) -> Option<String> {
+    std::fs::read(path)
+        .ok()
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn is_machine_read_file(name: &str) -> bool {
+    let path = Path::new(name);
+
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default();
+    if file_name.starts_with(".env") {
+        return true;
+    }
+
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| SCANNED_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()))
+}
+
+/// Structural detection of a password inside a URL userinfo: find `://`, then a
+/// `:` before the next `@`, with that `@` before the next `/`. No regex, so no
+/// new dependency.
+///
+/// The shape is deliberately not spelled out as a literal anywhere in this
+/// file: once tracked, this file is scanned by its own matcher.
+fn has_inline_credential(line: &str) -> bool {
+    let mut rest = line;
+
+    while let Some(scheme) = rest.find("://") {
+        let authority = &rest[scheme + "://".len()..];
+
+        if let (Some(at), Some(colon)) = (authority.find('@'), authority.find(':')) {
+            let ends_before_path = authority.find('/').is_none_or(|slash| at < slash);
+            let user = &authority[..colon];
+            let password = &authority[colon + 1..at.max(colon + 1)];
+            let is_userinfo = colon < at
+                && ends_before_path
+                && !user.is_empty()
+                && !password.is_empty()
+                && !user.contains(char::is_whitespace)
+                && !password.contains(char::is_whitespace);
+
+            if is_userinfo {
+                return true;
+            }
+        }
+
+        rest = authority;
+    }
+
+    false
+}
+
+fn offences(hit: impl Fn(&str) -> bool, only_machine_read: bool) -> Vec<String> {
+    let mut found = Vec::new();
+
+    for (name, path) in tracked_files() {
+        if only_machine_read && !is_machine_read_file(&name) {
+            continue;
+        }
+
+        let Some(text) = read_text(&path) else {
+            found.push(format!("{name}: tracked file could not be read"));
+            continue;
+        };
+
+        for (index, line) in text.lines().enumerate() {
+            if hit(line) {
+                found.push(format!("{name}:{}", index + 1));
+            }
+        }
+    }
+
+    found
+}
+
+#[test]
+fn no_tracked_machine_read_file_carries_an_inline_credential_url() {
+    let found = offences(has_inline_credential, true);
+
+    assert!(
+        found.is_empty(),
+        "a URL carrying a password in its userinfo was found in tracked files:\n  {}\n\
+         Remove the credential; the postgres password comes from RUSTY_CV_DB_PASSWORD.",
+        found.join("\n  ")
+    );
+}
+
+#[test]
+fn the_burned_credential_literal_never_reappears() {
+    let literal = burned_literal();
+    let found = offences(|line| line.contains(&literal), false);
+
+    assert!(
+        found.is_empty(),
+        "the burned credential literal reappeared in tracked files:\n  {}\n\
+         That value is in git history forever and must never be re-added.",
+        found.join("\n  ")
+    );
+}
+
+#[test]
+fn the_matcher_fires_on_a_known_bad_url() {
+    // Assembled from fragments so this file stays scanner-clean.
+    let scheme = "postgres";
+    let bad = format!("db_url = \"{scheme}://user{}pass@host/db\"", ':');
+    assert!(has_inline_credential(&bad), "matcher missed: {bad}");
+
+    let with_encoded_password = format!("{scheme}://user{}p%40ss@host/db", ':');
+    assert!(has_inline_credential(&with_encoded_password));
+}
+
+#[test]
+fn the_matcher_ignores_passwordless_and_pathological_urls() {
+    for clean in [
+        "postgres://rusty_cv@nixos-02.caracara-palermo.ts.net/rusty_cv",
+        "https://github.com/chess-seventh/cv.git",
+        "sqlite:///home/user/applications.db",
+        "see https://example.invalid/docs: ask bob@example.invalid",
+        "no scheme here at all",
+    ] {
+        assert!(!has_inline_credential(clean), "false positive on: {clean}");
+    }
+}
+
+#[test]
+fn the_scanned_set_covers_the_machine_read_file_kinds() {
+    for name in [
+        "devenv.nix",
+        "rusty-cv-config-example.ini",
+        "Cargo.toml",
+        "src/config_parse.rs",
+        ".github/workflows/build.yml",
+        "scripts/thing.yaml",
+        "scripts/thing.sh",
+        ".env",
+        ".env.testing",
+    ] {
+        assert!(is_machine_read_file(name), "should be scanned: {name}");
+    }
+
+    for name in ["README.md", "docs/product/architecture/brief.md", "LICENSE"] {
+        assert!(!is_machine_read_file(name), "should not be scanned: {name}");
+    }
+}

--- a/tests/db_credentials_regression.rs
+++ b/tests/db_credentials_regression.rs
@@ -124,10 +124,36 @@ fn has_inline_credential(line: &str) -> bool {
             }
         }
 
+        if has_password_query_parameter(authority) {
+            return true;
+        }
+
         rest = authority;
     }
 
     false
+}
+
+/// A password can also ride in the URL's query string, which PostgreSQL
+/// accepts and prefers over the one spliced into the userinfo. That form
+/// carries no colon before the `@`, so the userinfo matcher above is blind to
+/// it - it needs its own check or a plaintext credential ships undetected.
+fn has_password_query_parameter(url_tail: &str) -> bool {
+    let url = url_tail
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches(['"', '\'', ',', ';', ')']);
+
+    let Some(query) = url.split_once('?').map(|(_, query)| query) else {
+        return false;
+    };
+
+    query.split('&').any(|parameter| {
+        parameter
+            .split_once('=')
+            .is_some_and(|(key, value)| key.eq_ignore_ascii_case("password") && !value.is_empty())
+    })
 }
 
 fn hits_in(name: &str, text: &str, hit: &impl Fn(&str) -> bool, found: &mut Vec<String>) {

--- a/tests/integration-tests.rs
+++ b/tests/integration-tests.rs
@@ -41,7 +41,7 @@ quote_line_to_change = "QUOTE_PLACEHOLDER"
 db_path = "{}/db"
 db_file = "test.db"
 engine = "sqlite"
-db_pg_host = "postgresql://test:test@localhost/test"
+db_pg_host = "postgresql://test@localhost/test"
 
 [optional]
 pdf_viewer = "echo"


### PR DESCRIPTION
## What

Removes a plaintext PostgreSQL password from the tracked tree, sources it at
runtime from `RUSTY_CV_DB_PASSWORD`, and reconciles the database host and name
onto nixos-02/`rusty_cv`.

The password literal had been tracked since 2024-07-28 in two files:
`devenv.nix` and `rusty-cv-config-example.ini`. It remains in git history, so
the role password must be rotated when the database is recreated.

## How the password now works

- the INI holds a passwordless URL; the password comes from the environment
  and is percent-encoded and spliced in immediately before connecting
- a missing or empty variable is a hard error; there is no passwordless
  fallback connect
- a config that still carries a password is rejected in every form PostgreSQL
  honours: in the userinfo, and as a query parameter whose decoded name means
  a password, including an empty value
- the password is redacted from any driver error before it can be logged; the
  driver quotes the whole connection string back from several error branches
- both credential-bearing environment variables are stripped from every child
  process at a single spawn choke point

## Also fixed

- the database accessors now strip surrounding quotes, so the documented
  quoted config format actually resolves the postgres engine
- database errors on the insert and remove paths surface at error level
  instead of being swallowed

## The regression net

A scan fails the build if a credential-shaped URL lands in any tracked file
except markdown prose and binaries, and if the burned literal reappears
anywhere. There is no allowlist: a hit fixes the file, never the scanner. It
was verified to fail against the original tree.

## Verification

204 tests, clippy -D warnings clean, treefmt clean, no new dependency.
Eight independent blind verification passes; the last two returned green.
Seven earlier passes each found a real credential path and are fixed here.

## Deliberately not in this PR

- `GITHUB_TOKEN` is still inherited by child processes; `git` needs it, so
  closing it requires re-injection on the git path and gets its own change
- the migration is untouched; its SQLite incompatibility is documented

## Manual steps after merge

- strip the inline password from the live config file
- set a fresh password when the database is recreated
- export `RUSTY_CV_DB_PASSWORD` from sops via home-manager
